### PR TITLE
review book for many proposals, bugfixes

### DIFF
--- a/app/controllers/submitted_proposals_controller.rb
+++ b/app/controllers/submitted_proposals_controller.rb
@@ -518,7 +518,7 @@ class SubmittedProposalsController < ApplicationController
   end
 
   def check_proposals_reviews
-    @proposal_ids.each do |id|
+    @proposal_ids&.split(',')&.each do |id|
       @proposal = Proposal.find_by(id: id)
       reviews_conditions
     end

--- a/app/controllers/submitted_proposals_controller.rb
+++ b/app/controllers/submitted_proposals_controller.rb
@@ -154,7 +154,7 @@ class SubmittedProposalsController < ApplicationController
 
   def download_review_booklet
     pdf_file = Rails.root.join("tmp/proposal-reviews-#{current_user.id}.pdf")
-    year = Date.current.year
+    year = Date.current.year + 2
     filename = "#{year}-proposal-reviews.pdf"
     if File.exist?(pdf_file)
       file = File.open(pdf_file)

--- a/app/services/latex_attachments.rb
+++ b/app/services/latex_attachments.rb
@@ -62,9 +62,6 @@ module LatexAttachments
     [text, file_errors]
   end
 
-  def has_pdf_version?(review, filename)
-
-
   def add_file_to_tex(num, filename, full_filename)
     # scale first page 0.8 to avoid the page content overlapping the heading
     tex = "\\includepdf[scale=0.8,pages=1,pagecommand={\\subsection*

--- a/app/services/latex_attachments.rb
+++ b/app/services/latex_attachments.rb
@@ -27,7 +27,7 @@ module LatexAttachments
   # e.g. is there a PDF version of BIRS-210925-Smith-v1-Report-129020.docx?
   def pdf_version?(filename, base_name)
     (filename.gsub(/-(\d+)\.(.+)$/, '') == base_name) &&
-    (file_extension(filename) == 'pdf')
+      (file_extension(filename) == 'pdf')
   end
 
   def add_review_attachments(review, text, proposal, file_errors)

--- a/app/services/reviews_book.rb
+++ b/app/services/reviews_book.rb
@@ -80,16 +80,14 @@ class ReviewsBook
   end
 
   def booklet_title_page(year)
-    @proposal = Proposal.find_by(id: @proposals_id.first)
-    @text = "\\thispagestyle{empty}"
-    @text << "\\begin{center}"
-    @text << "\\includegraphics[width=4in]{birs_logo.jpg}\\\\ \n"
-    @text << "{\\writeblue\\titlefont Banff International\\\\
-                Research Station}\\\\ \n"
-    @text << "{\\writeblue\\titlefont #{year} Proposal Reviews}\\\\\n"
-    @text << "\\end{center}\n\n\n"
-    @text << "\\pagebreak"
-    @text << "\\tableofcontents"
+    @text = "\n\\thispagestyle{empty}\n"
+    @text << "\\begin{center}\n"
+    @text << "\\includegraphics[width=4in]{birs_logo.jpg}\\\\[30pt]\n"
+    @text << "{\\writeblue\\titlefont Banff International\\\\[10pt]
+                Research Station\\\\[0.5in]\n"
+    @text << "#{year} Proposals}\n"
+    @text << "\\end{center}\n\n"
+    @text << "\\newpage\n\n"
   end
 
   def organizers_list

--- a/app/services/reviews_book.rb
+++ b/app/services/reviews_book.rb
@@ -85,7 +85,7 @@ class ReviewsBook
     @text << "\\includegraphics[width=4in]{birs_logo.jpg}\\\\[30pt]\n"
     @text << "{\\writeblue\\titlefont Banff International\\\\[10pt]
                 Research Station\\\\[0.5in]\n"
-    @text << "#{year} Proposals}\n"
+    @text << "#{year} Proposal Reviews}\n"
     @text << "\\end{center}\n\n"
     @text << "\\newpage\n\n"
   end

--- a/app/views/layouts/booklet.pdf.erbtex
+++ b/app/views/layouts/booklet.pdf.erbtex
@@ -34,6 +34,16 @@
 \usepackage{graphicx}
 \graphicspath{{<%= "#{Rails.root}/app/assets/images/" %>}}
 
+% problem unicode characters
+\DeclareUnicodeCharacter{2028}{\linebreak}
+\DeclareUnicodeCharacter{03B5}{$\epsilon$}
+\DeclareUnicodeCharacter{03B4}{$\delta$}
+\DeclareUnicodeCharacter{2264}{$\leq$}
+\DeclareUnicodeCharacter{6731}{}
+\DeclareUnicodeCharacter{6625}{}
+\DeclareUnicodeCharacter{94A2}{}
+
+
 \DeclareMathOperator{\Gal}{Gal}
 \DeclareMathOperator{\SL}{SL}
 \DeclareMathOperator\ed{\mathrm{ed}}

--- a/app/views/submitted_proposals/_review_booklet_window.html.erb
+++ b/app/views/submitted_proposals/_review_booklet_window.html.erb
@@ -23,8 +23,8 @@
         </div>
       </div>
       <div class="modal-footer">
-        <a class="btn btn-secondary my-2" data-action="click->submitted-proposals#reviewsBooklet">Ok</a>
-        <a target="_blank" hidden="true" id="reviews_booklet" href="/submitted_proposals/download_review_booklet.pdf">Download Reviews Booklet</a>
+        <a class="btn btn-secondary my-2" data-action="click->submitted-proposals#reviewsBooklet">Generate New PDF</a>
+        <a class="btn btn-secondary my-2" target="_blank" id="reviews_booklet" href="/submitted_proposals/download_review_booklet.pdf">Download Reviews Booklet</a>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
       </div>
     </div>


### PR DESCRIPTION
As a work-around, I un-hid the _Download Reviews Booklet_ link in the _review_booklet_window so that the user could access the generated file, in the case of large PDFs that take over 60 seconds to compile. They get a "Something went wrong" message, even though nothing went wrong. See Trello card for details.

It would be good to do a proper fix for this. Please commit to this branch. Thanks!
