### PR TITLE
Correct validation of a proposal per type per year for organizers

### DIFF
--- a/app/concerns/callable.rb
+++ b/app/concerns/callable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Callable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def call(...)
+      new(...).call
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 class ApplicationController < ActionController::Base
   before_action :assign_ability, :set_current_user
 
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
+
   def assign_ability
     @ability = Ability.new(current_user)
   end
@@ -22,5 +25,19 @@ class ApplicationController < ActionController::Base
       return proposals_path if user&.organizer?(proposal)
     end
     new_proposal_path
+  end
+
+  def record_not_found
+    respond_to do |format|
+      format.js { render json: { errors: [I18n.t('errors.messages.resource_not_found')] }, status: 404 }
+      format.html { redirect_to root_path, alert: I18n.t('errors.messages.resource_not_found') }
+    end
+  end
+
+  def record_invalid
+    respond_to do |format|
+      format.js { render json: { errors: [I18n.t('errors.messages.something_went_wrong')] }, status: 404 }
+      format.html { redirect_to :back, alert: I18n.t('errors.messages.something_went_wrong') }
+    end
   end
 end

--- a/app/controllers/proposal_types_controller.rb
+++ b/app/controllers/proposal_types_controller.rb
@@ -53,7 +53,12 @@ class ProposalTypesController < ApplicationController
 
   def years
     @target = params[:target]
-    @proposal_types_years = ProposalType.find_by(id: params[:id])&.year&.split(",")&.map(&:strip) || [Date.current.year + 2]
+    proposal_type_year = ProposalType.find_by(id: params[:id])&.year
+    @years = if proposal_type_year
+               proposal_type_year.split(",").map(&:strip)
+             else
+               [Date.current.year + 2]
+             end
 
     respond_to do |format|
       format.turbo_stream

--- a/app/controllers/proposal_types_controller.rb
+++ b/app/controllers/proposal_types_controller.rb
@@ -51,6 +51,15 @@ class ProposalTypesController < ApplicationController
 
   def show; end
 
+  def years
+    @target = params[:target]
+    @proposal_types_years = ProposalType.find_by(id: params[:id])&.year&.split(",")&.map(&:strip) || [Date.current.year + 2]
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
   private
 
   def proposal_type_params

--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -203,10 +203,10 @@ class SubmitProposalsController < ApplicationController
 
   def staff_redirect
     if @submission.errors?
-      redirect_to edit_submitted_proposal_url(@proposal), alert: "Your submission has
+      redirect_to edit_submitted_proposal_path(@proposal), alert: "Your submission has
           errors: #{@submission.error_messages}.".squish
     else
-      redirect_to submitted_proposals_url(@proposal), notice: t('submit_proposals.staff_redirect.alert')
+      redirect_to submitted_proposals_path, notice: t('submit_proposals.staff_redirect.alert')
     end
   end
 

--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -14,19 +14,15 @@ class SubmitProposalsController < ApplicationController
 
     return create_invite if params[:create_invite] && request.xhr?
 
-    if current_user.staff_member?
-      staff_redirect
+    return staff_redirect if current_user.staff_member?
+
+    session[:is_submission] = @proposal.is_submission = @submission.final?
+
+    if !@proposal.is_submission
+      redirect_to edit_proposal_path(@proposal), notice: t('submit_proposals.create.alert')
     else
-      session[:is_submission] = @proposal.is_submission = @submission.final?
-
-      return redirect_to edit_proposal_path(@proposal) if result.errors?
-
-      if !@proposal.is_submission
-        return redirect_to edit_proposal_path(@proposal), notice: t('submit_proposals.create.alert')
-      else
-        @attachment = generate_proposal_pdf || return
-        confirm_submission
-      end
+      @attachment = generate_proposal_pdf || return
+      confirm_submission
     end
   end
 

--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -11,7 +11,7 @@ class SubmitProposalsController < ApplicationController
     @proposal = result.proposal
 
     if result.errors?
-      flash[:alert] = result.flash_errors[:alert]
+      flash[:alert] = result.flash_message[:alert]
     end
 
     return create_invite if params[:create_invite] && request.xhr?

--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -106,7 +106,7 @@ class SubmitProposalsController < ApplicationController
   end
 
   def proposal_service_params
-    params.merge(ams_subjects: params[:ams_subjects], commit: params[:commit], no_latex: params[:no_latex] == 'on')
+    params.merge(no_latex: params[:no_latex] == 'on')
   end
 
   def proposal_id_param

--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -10,9 +10,7 @@ class SubmitProposalsController < ApplicationController
     @submission = result.submission
     @proposal = result.proposal
 
-    if result.errors?
-      flash[:alert] = result.flash_message[:alert]
-    end
+    return redirect_to edit_proposal_path(@proposal), **result.flash_message if result.errors?
 
     return create_invite if params[:create_invite] && request.xhr?
 

--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -17,7 +17,8 @@ class SubmitProposalsController < ApplicationController
     session[:is_submission] = @proposal.is_submission = @submission.final?
 
     if @proposal.is_submission
-      @attachment = generate_proposal_pdf
+      # TODO: move sending email with pdf attachment to a job
+      @attachment = generate_proposal_pdf || return
       confirm_submission
     else
       redirect_to edit_proposal_path(@proposal), notice: t('submit_proposals.create.alert')

--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -14,7 +14,7 @@ class SubmitProposalsController < ApplicationController
       flash[:alert] = result.flash_errors[:alert]
     end
 
-    return create_invite if params[:create_invite]
+    return create_invite if params[:create_invite] && request.xhr?
 
     if current_user.staff_member?
       staff_redirect

--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -105,15 +105,8 @@ class SubmitProposalsController < ApplicationController
                 alert: error_message and return
   end
 
-  def proposal_params
-    params.permit(:title, :year, :subject_id, :ams_subject_ids, :location_ids,
-                  :no_latex, :preamble, :bibliography, :cover_letter, :applied_date,
-                  :same_week_as, :week_after, :assigned_date, :assigned_size)
-          .merge(no_latex: params[:no_latex] == 'on')
-  end
-
   def proposal_service_params
-    proposal_params.merge(ams_subjects: params[:ams_subjects], commit: params[:commit])
+    params.merge(ams_subjects: params[:ams_subjects], commit: params[:commit], no_latex: params[:no_latex] == 'on')
   end
 
   def proposal_id_param

--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -43,12 +43,9 @@ class SubmitProposalsController < ApplicationController
       @email_template = EmailTemplate.find_by(email_type: "participant_invitation_type")
     end
 
-    if @template_body.blank?
-      redirect_to new_email_template_path, alert: t('submit_proposals.preview_placeholders.failure')
-    else
-      render json: { subject: @email_template&.subject, body: @template_body },
-             status: :ok
-    end
+    preview_placeholders
+    render json: { subject: @email_template.subject, body: @template_body },
+           status: :ok
   end
 
   private

--- a/app/controllers/submitted_proposals_controller.rb
+++ b/app/controllers/submitted_proposals_controller.rb
@@ -49,12 +49,13 @@ class SubmittedProposalsController < ApplicationController
 
   def revise_proposal_editflow
     @proposal = Proposal.find_by(id: params[:proposal_id].to_i)
+
     unless @proposal.may_requested? || @proposal.may_revision?
       return redirect_to versions_proposal_url(@proposal),
                   alert: "Proposal status should be initial_review or revision_submitted_before_review."
     end
+
     check_proposal_editflow_id
-    nil
   end
 
   def staff_discussion

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -16,10 +16,10 @@ module ProposalsHelper
           .where.not(status: 'cancelled')
   end
 
-  def proposal_type_year(proposal_type)
-    return [Date.current.year + 2] if proposal_type.year.blank?
+  def proposal_type_year(proposal_type = nil)
+    return [Date.current.year + 2] if proposal_type&.year.blank?
 
-    proposal_type.year&.split(",")&.map(&:strip)
+    proposal_type&.year&.split(",")&.map(&:strip)
   end
 
   def approved_proposals(proposal)

--- a/app/javascript/controllers/nested_invites_controller.js
+++ b/app/javascript/controllers/nested_invites_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
     organizer: Number,
     participant: Number
   }
- 
+
   initialize () {
     this.wrapperSelector = this.wrapperSelectorValue || '.nested-invites-wrapper'
   }
@@ -124,7 +124,7 @@ export default class extends Controller {
     let inviteParticipant = event.currentTarget.dataset.participant || 0
     let inviteOrganizer = event.currentTarget.dataset.organizer || 0
     var body = $('#email_body').text()
-    $.post(`/submit_proposals?proposal=${id}&create_invite=true.js`,
+    $.post(`/submit_proposals/create_invite?proposal=${id}`,
       $('form#submit_proposal').serialize(), function(data) {
         if (body.toLowerCase().includes("supporting organizer")) {
           invitedAs = 'Organizer'
@@ -136,7 +136,7 @@ export default class extends Controller {
         }
         _this.sendInviteEmails(id, invitedAs, inviteId, data)
       }
-    ) 
+    )
     .fail(function(response) {
       let errors = response.responseJSON
       $.each(errors, function(index, error) {

--- a/app/javascript/controllers/submit_proposals_controller.js
+++ b/app/javascript/controllers/submit_proposals_controller.js
@@ -2,10 +2,12 @@ import { Controller } from "stimulus"
 import Sortable from "sortablejs"
 import Rails from '@rails/ujs'
 
+import { get } from '@rails/request.js'
+
 export default class extends Controller {
 
-  static targets = [ 'proposalType', 'locationSpecificQuestions', 'locationIds', 'text', 'tabs', 
-                    'dragLocations', 'latexPreamble', 'latexBibliography', 'proposalVersion' ]
+  static targets = [ 'proposalType', 'locationSpecificQuestions', 'locationIds', 'text', 'tabs',
+                    'dragLocations', 'latexPreamble', 'latexBibliography', 'proposalVersion', 'yearSelect' ]
   static values = { proposalTypeId: Number, proposal: Number }
 
   connect() {
@@ -128,5 +130,14 @@ export default class extends Controller {
       this.latexPreambleTarget.classList.remove("hidden")
       this.latexBibliographyTarget.classList.remove("hidden")
     }
+  }
+
+  fillProposalYears(event) {
+    let id = event.target.selectedOptions[0].value
+    let target = this.yearSelectTarget.id
+
+    get(`/proposal_types/${id}/years?target=${target}`, {
+      responseKind: 'turbo-stream'
+    })
   }
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,6 +11,8 @@ import "jquery"
 import "bootstrap"
 import "@fortawesome/fontawesome-free/css/all"
 import "@yaireo/tagify"
+import "@hotwired/turbo-rails"
+import "@rails/request.js"
 
 import "../../../vendor/assets/javascripts/spark"
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -19,6 +19,8 @@ import "../../../vendor/assets/javascripts/spark"
 import "../stylesheets/application"
 import "../js/common";
 
+window.Turbo = require("@hotwired/turbo")
+
 // Toastr flash messages
 global.toastr = require("toastr")
 toastr.options.closeButton = true;

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -7,7 +7,7 @@ class Person < ApplicationRecord
   has_many :proposal_roles, dependent: :destroy
   has_many :proposals, through: :proposal_roles
   has_many :proposal_organizer_roles, -> { lead_organizer }, class_name: 'ProposalRole'
-  has_many :lead_organizer_proposals, -> { not_draft }, source: :proposal, through: :proposal_organizer_roles
+  has_many :lead_organizer_proposals, source: :proposal, through: :proposal_organizer_roles
   has_one :demographic_data, dependent: :destroy
   has_many :reviews, dependent: :destroy
   before_save :downcase_email

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -6,6 +6,8 @@ class Person < ApplicationRecord
   belongs_to :user, optional: true
   has_many :proposal_roles, dependent: :destroy
   has_many :proposals, through: :proposal_roles
+  has_many :proposal_organizer_roles, -> { lead_organizer }, class_name: 'ProposalRole'
+  has_many :lead_organizer_proposals, -> { not_draft }, source: :proposal, through: :proposal_organizer_roles
   has_one :demographic_data, dependent: :destroy
   has_many :reviews, dependent: :destroy
   before_save :downcase_email

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -128,8 +128,6 @@ class Proposal < ApplicationRecord
     where(status: 'submitted')
   }
 
-  scope :not_draft, -> { where.not(status: 'draft') }
-
   scope :no_of_participants, lambda { |id, invited_as|
     joins(:invites).where('invites.invited_as = ?
       AND invites.proposal_id = ?', invited_as, id)

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -128,6 +128,8 @@ class Proposal < ApplicationRecord
     where(status: 'submitted')
   }
 
+  scope :not_draft, -> { where.not(status: 'draft') }
+
   scope :no_of_participants, lambda { |id, invited_as|
     joins(:invites).where('invites.invited_as = ?
       AND invites.proposal_id = ?', invited_as, id)

--- a/app/models/proposal_role.rb
+++ b/app/models/proposal_role.rb
@@ -2,4 +2,6 @@ class ProposalRole < ApplicationRecord
   belongs_to :proposal
   belongs_to :role
   belongs_to :person
+
+  scope :lead_organizer, -> { joins(:role).where(roles: { name: 'lead_organizer' }) }
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -8,4 +8,10 @@ class Role < ApplicationRecord
   has_many :proposal_roles, dependent: :destroy
 
   accepts_nested_attributes_for :role_privileges, reject_if: :all_blank, allow_destroy: true
+
+  class << self
+    def organizer
+      find_or_create_by!(name: 'lead_organizer')
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,8 +23,7 @@ class User < ApplicationRecord
   end
 
   def staff_member?
-    staff = Role.find_by(name: 'Staff')
-    roles.include?(staff)
+    roles.exists?(name: 'Staff')
   end
 
   def organizer?(proposal)

--- a/app/services/proposals/initialize.rb
+++ b/app/services/proposals/initialize.rb
@@ -32,20 +32,27 @@ module Proposals
     end
 
     def call
-      ActiveRecord::Base.transaction do
-        attach_form
-        new_proposal.save!
-        ensure_organizer_role
+      create_proposal
 
-        Result.new(flash_message: { notice: I18n.t('proposals.initialize', proposal_type: new_proposal.proposal_type.name) }, proposal: new_proposal)
-      rescue
-        Result.new(flash_message: { alert: new_proposal.errors.full_messages }, proposal: new_proposal)
-      end
+      Result.new(
+        flash_message: { notice: I18n.t('proposals.initialize', proposal_type: new_proposal.proposal_type.name) },
+        proposal: new_proposal
+      )
+    rescue
+      Result.new(flash_message: { alert: new_proposal.errors.full_messages }, proposal: new_proposal)
     end
 
     private
 
     attr_reader :current_user, :proposal_params
+
+    def create_proposal
+      ActiveRecord::Base.transaction do
+        attach_form
+        new_proposal.save
+        ensure_organizer_role
+      end
+    end
 
     def attach_form
       new_proposal.proposal_form = ProposalForm.active_form(new_proposal.proposal_type_id)

--- a/app/services/proposals/initialize.rb
+++ b/app/services/proposals/initialize.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Proposals
+  class Initialize
+    include Callable
+    include Rails.application.routes.url_helpers
+
+    Result = Struct.new(:flash_message, :proposal, url: nil, keyword_init: true) do
+      def redirect_url
+        return url if url
+
+        if flash_message[:notice]
+          edit_proposal_path(proposal)
+        else
+          new_proposal_path
+        end
+      end
+
+      def errors?
+        flash_message[:error].present? || flash_message[:alert].present?
+      end
+    end
+
+    def initialize(current_user:, proposal_params:)
+      @current_user = current_user
+      @proposal_params = proposal_params
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        attach_form
+        new_proposal.save!
+        ensure_organizer_role
+
+        Result.new(flash_message: { notice: I18n.t('proposals.initialize', proposal_type: new_proposal.proposal_type.name) }, proposal: new_proposal)
+      rescue
+        Result.new(flash_message: { alert: new_proposal.errors.full_messages }, proposal: new_proposal)
+      end
+    end
+
+    private
+
+    attr_reader :current_user, :proposal_params
+
+    def attach_form
+      new_proposal.proposal_form = ProposalForm.active_form(new_proposal.proposal_type_id)
+    end
+
+    def ensure_organizer_role
+      new_proposal.create_organizer_role(current_user.person, organizer_role)
+    end
+
+    def new_proposal
+      @new_proposal ||= Proposal.new(proposal_params)
+    end
+
+    def organizer_role
+      @organizer_role ||= Role.organizer
+    end
+  end
+end

--- a/app/services/proposals/initialize.rb
+++ b/app/services/proposals/initialize.rb
@@ -3,9 +3,14 @@
 module Proposals
   class Initialize
     include Callable
-    include Rails.application.routes.url_helpers
 
-    Result = Struct.new(:flash_message, :proposal, url: nil, keyword_init: true) do
+    Result = Struct.new(:flash_message, :proposal, :url, keyword_init: true) do
+      include Rails.application.routes.url_helpers
+
+      def initialize(flash_message:, proposal:, url: nil)
+        super
+      end
+
       def redirect_url
         return url if url
 

--- a/app/services/proposals/initialize.rb
+++ b/app/services/proposals/initialize.rb
@@ -22,7 +22,7 @@ module Proposals
       end
 
       def errors?
-        flash_message[:error].present? || flash_message[:alert].present?
+        flash_message[:alert].present?
       end
     end
 
@@ -39,7 +39,7 @@ module Proposals
         proposal: new_proposal
       )
     rescue
-      Result.new(flash_message: { alert: new_proposal.errors.full_messages }, proposal: new_proposal)
+      Result.new(flash_message: { alert: error_message }, proposal: new_proposal)
     end
 
     private
@@ -68,6 +68,14 @@ module Proposals
 
     def organizer_role
       @organizer_role ||= Role.organizer
+    end
+
+    def error_message
+      if new_proposal.errors.present?
+        new_proposal.errors.full_messages
+      else
+        I18n.t('errors.messages.something_went_wrong')
+      end
     end
   end
 end

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -99,15 +99,11 @@ module Proposals
     def limit_per_type_per_year_exceeded?
       return @exists_query_result if defined?(@exists_query_result)
 
-      current_user_proposal_ids = ProposalRole.joins(:role, :person)
-        .where(roles: { name: 'lead_organizer' }, person: { id: current_user.person.id })
-        .pluck(:proposal_id)
+      @exists_query_result = current_user
+                              .person
+                              .lead_organizer_proposals
+                              .exists?(proposal_type_id: proposal.proposal_type_id, year: model_params[:year])
 
-      @exists_query_result = Proposal.exists?(
-        proposal_type_id: proposal.proposal_type_id,
-        year: model_params[:year],
-        id: current_user_proposal_ids
-      )
     end
 
     def update_ams_subject_codes

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module Proposals
+  class Update
+    include Callable
+
+    MODEL_ATTRS = %i[title year subject_id ams_subject_ids location_ids
+                  no_latex preamble bibliography cover_letter applied_date
+                  same_week_as week_after assigned_date assigned_size]
+
+    Result = Struct.new(:submission, :proposal, keyword_init: true) do
+      def flash_errors
+        return @flash_errors if defined?(@flash_errors)
+
+        if errors?
+          messages = { alert: [] }
+
+          proposal.errors.full_messages.each do |error|
+            messages[:alert] << error
+          end
+
+          submission.error_messages.each do |error|
+            messages[:alert] << error.to_s
+          end
+
+          @flash_errors = messages
+        else
+          @flash_errors = {}
+        end
+      end
+
+      def errors?
+        proposal.errors.present? || submission.errors?
+      end
+    end
+
+    def initialize(current_user:, proposal:, params:)
+      @current_user = current_user
+      @proposal = proposal
+      @params = params
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        proposal.update(model_params.except(:year))
+        update_year
+        update_ams_subject_codes
+        submit_proposal
+
+        Result.new(submission: submission, proposal: proposal)
+      rescue
+        Result.new(submission: submission, proposal: proposal)
+      end
+    end
+
+    private
+
+    attr_reader :proposal, :params, :current_user
+
+    def model_params
+      @model_params ||= params.slice(MODEL_ATTRS).tap do |proposal_params|
+        applied_date = proposal_params[:applied_date]
+
+        if applied_date
+          proposal_params[:applied_date] = Date.parse(applied_date.split(' - ').first)
+        end
+
+        assigned_date = proposal_params[:assigned_date]
+
+        if assigned_date
+          proposal_params[:assigned_date] = Date.parse(assigned_date.split(' - ').first)
+        end
+      end
+    end
+
+    def update_year
+      if limit_per_type_per_year_exhausted?
+        proposal.errors.add(
+          :year,
+          I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)
+        )
+      else
+        proposal.update(year: model_params[:year])
+      end
+    end
+
+    def limit_per_type_per_year_exhausted?
+      return @exists_query_result if defined?(@exists_query_result)
+
+      current_user_proposal_ids = ProposalRole.joins(:role, :person)
+        .where(roles: { name: 'lead_organizer' }, person: { id: current_user.person.id })
+        .pluck(:proposal_id)
+
+      @exists_query_result = Proposal.exists?(
+        proposal_type_id: proposal.proposal_type_id,
+        year: model_params[:year],
+        id: current_user_proposal_ids
+      )
+    end
+
+    def update_ams_subject_codes
+      first_ams_subject = ProposalAmsSubject.find_or_initialize_by(proposal: proposal, code: 'code1')
+      first_ams_subject.ams_subject_id = params.dig(:ams_subjects, :code1)
+      first_ams_subject.save!
+
+      second_ams_subject = ProposalAmsSubject.find_or_initialize_by(proposal: proposal, code: 'code2')
+      second_ams_subject.ams_subject_id = params.dig(:ams_subjects, :code2)
+      second_ams_subject.save!
+    end
+
+    def submit_proposal
+      submission.save_answers
+    end
+
+    def submission
+      @submission ||= SubmitProposalService.new(proposal, params)
+    end
+  end
+end

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -71,18 +71,14 @@ module Proposals
     end
 
     def model_params
-      @model_params ||= params.dup.permit(*MODEL_ATTRS).tap do |proposal_params|
+      @model_params ||= params.dup.slice(*MODEL_ATTRS).tap do |proposal_params|
         applied_date = proposal_params[:applied_date]
 
-        if applied_date
-          proposal_params[:applied_date] = Date.parse(applied_date.split(' - ').first)
-        end
+        proposal_params[:applied_date] = Date.parse(applied_date.split(' - ').first) if applied_date
 
         assigned_date = proposal_params[:assigned_date]
 
-        if assigned_date
-          proposal_params[:assigned_date] = Date.parse(assigned_date.split(' - ').first)
-        end
+        proposal_params[:assigned_date] = Date.parse(assigned_date.split(' - ').first) if assigned_date
       end.compact
     end
 

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -81,11 +81,11 @@ module Proposals
         assigned_date = proposal_params[:assigned_date]
 
         proposal_params[:assigned_date] = Date.parse(assigned_date.split(' - ').first) if assigned_date.present?
-
-        proposal_params.permit(*MODEL_ATTRS) if proposal_params.respond_to?(:permit)
       end.compact
 
       @model_params = @model_params.permit(*MODEL_ATTRS) if @model_params.respond_to?(:permit)
+
+      @model_params
     end
 
     def update_ams_subject_codes

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -63,8 +63,8 @@ module Proposals
 
     def update_proposal
       ActiveRecord::Base.transaction do
-        proposal.update(model_params)
-        validate
+        proposal.assign_attributes(model_params)
+        validate_and_save
         update_ams_subject_codes
         submit_proposal
       end
@@ -82,10 +82,6 @@ module Proposals
 
         if assigned_date
           proposal_params[:assigned_date] = Date.parse(assigned_date.split(' - ').first)
-        end
-
-        if limit_per_type_per_year_exceeded?
-          proposal_params[:year] = nil
         end
       end.compact
     end

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -71,7 +71,7 @@ module Proposals
     end
 
     def model_params
-      @model_params ||= params.dup.slice(*MODEL_ATTRS).tap do |proposal_params|
+      @model_params ||= params.dup.permit(*MODEL_ATTRS).tap do |proposal_params|
         applied_date = proposal_params[:applied_date]
 
         proposal_params[:applied_date] = Date.parse(applied_date.split(' - ').first) if applied_date

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -71,7 +71,9 @@ module Proposals
     end
 
     def model_params
-      @model_params ||= params.dup.slice(*MODEL_ATTRS).tap do |proposal_params|
+      return @model_params if defined?(@model_params)
+
+      @model_params = params.dup.slice(*MODEL_ATTRS).tap do |proposal_params|
         applied_date = proposal_params[:applied_date]
 
         proposal_params[:applied_date] = Date.parse(applied_date.split(' - ').first) if applied_date.present?
@@ -82,6 +84,8 @@ module Proposals
 
         proposal_params.permit(*MODEL_ATTRS) if proposal_params.respond_to?(:permit)
       end.compact
+
+      @model_params = @model_params.permit(*MODEL_ATTRS) if @model_params.respond_to?(:permit)
     end
 
     def update_ams_subject_codes

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -71,7 +71,7 @@ module Proposals
     end
 
     def model_params
-      @model_params ||= params.dup.permit(*MODEL_ATTRS).tap do |proposal_params|
+      @model_params ||= params.dup.slice(*MODEL_ATTRS).tap do |proposal_params|
         applied_date = proposal_params[:applied_date]
 
         proposal_params[:applied_date] = Date.parse(applied_date.split(' - ').first) if applied_date.present?
@@ -79,6 +79,8 @@ module Proposals
         assigned_date = proposal_params[:assigned_date]
 
         proposal_params[:assigned_date] = Date.parse(assigned_date.split(' - ').first) if assigned_date.present?
+
+        proposal_params.permit(*MODEL_ATTRS) if proposal_params.respond_to?(:permit)
       end.compact
     end
 

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -9,8 +9,8 @@ module Proposals
                   same_week_as week_after assigned_date assigned_size]
 
     Result = Struct.new(:submission, :proposal, keyword_init: true) do
-      def flash_errors
-        return @flash_errors if defined?(@flash_errors)
+      def flash_message
+        return @flash_message if defined?(@flash_message)
 
         if errors?
           messages = { alert: [] }
@@ -23,9 +23,9 @@ module Proposals
             messages[:alert] << error.to_s
           end
 
-          @flash_errors = messages
+          @flash_message = messages
         else
-          @flash_errors = {}
+          @flash_message = {}
         end
       end
 
@@ -78,7 +78,7 @@ module Proposals
     end
 
     def update_year
-      if limit_per_type_per_year_exhausted?
+      if limit_per_type_per_year_exceeded?
         proposal.errors.add(
           :base,
           I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)
@@ -88,7 +88,7 @@ module Proposals
       end
     end
 
-    def limit_per_type_per_year_exhausted?
+    def limit_per_type_per_year_exceeded?
       return @exists_query_result if defined?(@exists_query_result)
 
       current_user_proposal_ids = ProposalRole.joins(:role, :person)
@@ -103,13 +103,25 @@ module Proposals
     end
 
     def update_ams_subject_codes
-      first_ams_subject = ProposalAmsSubject.find_or_initialize_by(proposal: proposal, code: 'code1')
-      first_ams_subject.ams_subject_id = params.dig(:ams_subjects, :code1)
-      first_ams_subject.save!
+      if first_ams_subject
+        first_ams_subject = ProposalAmsSubject.find_or_initialize_by(proposal: proposal, code: 'code1')
+        first_ams_subject.ams_subject_id = first_ams_subject
+        first_ams_subject.save!
+      end
 
-      second_ams_subject = ProposalAmsSubject.find_or_initialize_by(proposal: proposal, code: 'code2')
-      second_ams_subject.ams_subject_id = params.dig(:ams_subjects, :code2)
-      second_ams_subject.save!
+      if second_ams_subject
+        second_ams_subject = ProposalAmsSubject.find_or_initialize_by(proposal: proposal, code: 'code2')
+        second_ams_subject.ams_subject_id = second_ams_subject
+        second_ams_subject.save!
+      end
+    end
+
+    def first_ams_subject
+      params.dig(:ams_subjects, :code1)
+    end
+
+    def second_ams_subject
+      params.dig(:ams_subjects, :code2)
     end
 
     def submit_proposal

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -6,8 +6,8 @@ module Proposals
     include UpsertProposalValidator
 
     MODEL_ATTRS = %i[title year subject_id ams_subject_ids location_ids
-                  no_latex preamble bibliography cover_letter applied_date
-                  same_week_as week_after assigned_date assigned_size]
+                     no_latex preamble bibliography cover_letter applied_date
+                     same_week_as week_after assigned_date assigned_size].freeze
 
     Result = Struct.new(:submission, :proposal, :error_messages, keyword_init: true) do
       def initialize(submission:, proposal:, error_messages: [])
@@ -71,7 +71,7 @@ module Proposals
     end
 
     def model_params
-      @model_params ||= params.dup.slice(*MODEL_ATTRS).tap do |proposal_params|
+      @model_params ||= params.dup.permit(*MODEL_ATTRS).tap do |proposal_params|
         applied_date = proposal_params[:applied_date]
 
         if applied_date

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -74,11 +74,11 @@ module Proposals
       @model_params ||= params.dup.permit(*MODEL_ATTRS).tap do |proposal_params|
         applied_date = proposal_params[:applied_date]
 
-        proposal_params[:applied_date] = Date.parse(applied_date.split(' - ').first) if applied_date
+        proposal_params[:applied_date] = Date.parse(applied_date.split(' - ').first) if applied_date.present?
 
         assigned_date = proposal_params[:assigned_date]
 
-        proposal_params[:assigned_date] = Date.parse(assigned_date.split(' - ').first) if assigned_date
+        proposal_params[:assigned_date] = Date.parse(assigned_date.split(' - ').first) if assigned_date.present?
       end.compact
     end
 

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -62,8 +62,8 @@ module Proposals
 
     def update_proposal
       ActiveRecord::Base.transaction do
+        assign_year
         proposal.update(model_params.except(:year))
-        update_year
         update_ams_subject_codes
         submit_proposal
       end
@@ -85,14 +85,14 @@ module Proposals
       end
     end
 
-    def update_year
+    def assign_year
       if limit_per_type_per_year_exceeded?
         proposal.errors.add(
           :base,
           I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)
         )
       else
-        proposal.update(year: model_params[:year])
+        proposal.assign_attributes(year: model_params[:year])
       end
     end
 
@@ -102,8 +102,8 @@ module Proposals
       @exists_query_result = current_user
                               .person
                               .lead_organizer_proposals
+                              .where.not(id: proposal.id)
                               .exists?(proposal_type_id: proposal.proposal_type_id, year: model_params[:year])
-
     end
 
     def update_ams_subject_codes

--- a/app/validators/upsert_proposal_validator.rb
+++ b/app/validators/upsert_proposal_validator.rb
@@ -8,13 +8,13 @@ module UpsertProposalValidator
     validate
     rollback_invalid_attributes
 
-    unless validation_errors? && halt_on_error
+    if validation_errors? && halt_on_error
+      raise ActiveRecord::RecordInvalid
+    else
       proposal.save
     end
-
+  ensure
     populate_errors
-
-    raise ActiveRecord::RecordInvalid if validation_errors? && halt_on_error
   end
 
   private

--- a/app/validators/upsert_proposal_validator.rb
+++ b/app/validators/upsert_proposal_validator.rb
@@ -1,16 +1,45 @@
 # frozen_string_literal: true
 
+# I did not really want Proposal to run heavy validations each time a record is created,
+# that is why this is not using `validate_with klass`. The main
 module UpsertProposalValidator
   def validate
-    if limit_per_type_per_year_exceeded?
-      proposal.errors.add(
-        :base,
-        I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)
-      )
+    check_limit_per_type_per_year
+  end
+
+  def errors_map
+    @errors_map ||= {
+      year:  I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)
+    }
+  end
+
+  def populate_errors
+    validation_errors.each do |attr|
+      next unless errors_map[attr]
+
+      proposal.errors.add(attr, errors_map[attr])
     end
   end
 
-  def limit_per_type_per_year_exceeded?
+  def rollback_invalid_attributes
+    validation_errors.each do |attr|
+      proposal.public_send("#{attr}=".to_sym, proposal.public_send("#{attr}_was".to_sym))
+    rescue
+      next
+    end
+  end
+
+  def validate_and_save(halt_on_error: false)
+    # works around ActiveRecord clearing custom errors on save
+    validate
+    rollback_invalid_attributes
+    proposal.save unless halt_on_error
+    populate_errors
+
+    raise ActiveRecord::RecordInvalid if validation_errors.present? && halt_on_error
+  end
+
+  def check_limit_per_type_per_year
     return @exists_query_result if defined?(@exists_query_result)
 
     return @exists_query_result = false unless params[:year]
@@ -20,5 +49,13 @@ module UpsertProposalValidator
                              .lead_organizer_proposals
                              .where.not(id: proposal.id)
                              .exists?(proposal_type_id: proposal.proposal_type_id, year: params[:year])
+
+    validation_errors << :year if @exists_query_result
+  end
+
+  private
+
+  def validation_errors
+    @validation_errors ||= []
   end
 end

--- a/app/validators/upsert_proposal_validator.rb
+++ b/app/validators/upsert_proposal_validator.rb
@@ -1,42 +1,26 @@
 # frozen_string_literal: true
 
-# I did not really want Proposal to run heavy validations each time a record is created,
-# that is why this is not using `validate_with klass`. The main
+# I did not really want Proposal to run heavy validations each time a record is saved,
+# that is why this is not using `validate_with klass` in proposal.rb.
 module UpsertProposalValidator
-  def validate
-    check_limit_per_type_per_year
-  end
-
-  def errors_map
-    @errors_map ||= {
-      year:  I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)
-    }
-  end
-
-  def populate_errors
-    validation_errors.each do |attr|
-      next unless errors_map[attr]
-
-      proposal.errors.add(attr, errors_map[attr])
-    end
-  end
-
-  def rollback_invalid_attributes
-    validation_errors.each do |attr|
-      proposal.public_send("#{attr}=".to_sym, proposal.public_send("#{attr}_was".to_sym))
-    rescue
-      next
-    end
-  end
-
+  # works around ActiveRecord clearing custom errors on save
   def validate_and_save(halt_on_error: false)
-    # works around ActiveRecord clearing custom errors on save
     validate
     rollback_invalid_attributes
-    proposal.save unless halt_on_error
+
+    unless validation_errors? && halt_on_error
+      proposal.save
+    end
+
     populate_errors
 
-    raise ActiveRecord::RecordInvalid if validation_errors.present? && halt_on_error
+    raise ActiveRecord::RecordInvalid if validation_errors? && halt_on_error
+  end
+
+  private
+
+  def validate
+    check_limit_per_type_per_year
   end
 
   def check_limit_per_type_per_year
@@ -53,9 +37,33 @@ module UpsertProposalValidator
     validation_errors << :year if @exists_query_result
   end
 
-  private
-
   def validation_errors
     @validation_errors ||= []
+  end
+
+  def rollback_invalid_attributes
+    validation_errors.each do |attr|
+      proposal.public_send("#{attr}=".to_sym, proposal.public_send("#{attr}_was".to_sym))
+    rescue
+      next
+    end
+  end
+
+  def populate_errors
+    validation_errors.each do |attr|
+      next unless errors_map[attr]
+
+      proposal.errors.add(attr, errors_map[attr])
+    end
+  end
+
+  def errors_map
+    @errors_map ||= {
+      year:  I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)
+    }
+  end
+
+  def validation_errors?
+    validation_errors.present?
   end
 end

--- a/app/validators/upsert_proposal_validator.rb
+++ b/app/validators/upsert_proposal_validator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module UpsertProposalValidator
+  def validate
+    if limit_per_type_per_year_exceeded?
+      proposal.errors.add(
+        :base,
+        I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)
+      )
+    end
+  end
+
+  def limit_per_type_per_year_exceeded?
+    return @exists_query_result if defined?(@exists_query_result)
+
+    return @exists_query_result = false unless params[:year]
+
+    @exists_query_result = current_user
+                             .person
+                             .lead_organizer_proposals
+                             .where.not(id: proposal.id)
+                             .exists?(proposal_type_id: proposal.proposal_type_id, year: params[:year])
+  end
+end

--- a/app/views/layouts/_toastr.html.erb
+++ b/app/views/layouts/_toastr.html.erb
@@ -3,7 +3,7 @@
   <script type="text/javascript">
     <% flash.each do |key, value| %>
       <% type = key.to_s.gsub('alert', 'error').gsub('notice', 'success') %>
-        <% if value.kind_of?(Array) %>
+        <% if value.respond_to?(:each) %>
           <% value&.each do |msg| %>
             toastr.<%= type %>('<%= msg %>')
           <% end %>

--- a/app/views/proposal_types/years.turbo_stream.erb
+++ b/app/views/proposal_types/years.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.update @target do %>
-  <%= options_for_select @proposal_types_years %>
+  <%= options_for_select @years %>
 <% end %>

--- a/app/views/proposal_types/years.turbo_stream.erb
+++ b/app/views/proposal_types/years.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update @target do %>
+  <%= options_for_select @proposal_types_years %>
+<% end %>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -134,7 +134,7 @@
 
                         <div class="mb-3">
                           <%= f.label :year %>
-                          <%= f.select :year, options_for_select(proposal_type_year(@proposal.proposal_type),  @proposal.year), {}, disabled: action, class: "form-select w-25", data: {'action': 'focus->auto-save-proposal#onFocus blur->auto-save-proposal#onBlur'} %>
+                          <%= f.select :year, options_for_select(proposal_type_year(@proposal.proposal_type),  @proposal.year), { include_blank: true }, disabled: action, class: "form-select w-25", data: {'action': 'focus->auto-save-proposal#onFocus blur->auto-save-proposal#onBlur'} %>
                         </div>
                         <div class="mb-3 row">
                           <h3 class="form-section">Subject Areas</h3>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -4,7 +4,7 @@
         <% if params[:action] == 'show'%>
          <% unless proposal.submitted? || proposal.revision_submitted? ||
             proposal.revision_submitted_spc? || proposal.approved? || proposal.declined? || proposal.decision_email_sent? || proposal.decision_pending? || proposal.initial_review? || proposal.in_progress? || proposal.in_progress_spc? %>
-          
+
           <div class="d-flex flex-row-reverse float-end" >
                <%= link_to "Edit Proposal", edit_proposal_path(@proposal) ,class:'btn btn-primary' %>
           </div>
@@ -15,7 +15,7 @@
       </h1>
        <nav aria-label="breadcrumb">
          <ol class="breadcrumb" data-turbo="false">
-           <li class="breadcrumb-item"> <%= link_to "Dashboard", dashboards_path %> </a></li>
+           <li class="breadcrumb-item"> <%= link_to "Dashboard", dashboards_path %></li>
           <li class="breadcrumb-item active" aria-current="page"><%= link_to "Proposals", proposals_path %></li>
           <% if params[:action] == 'edit' %>
             <li class="breadcrumb-item active" aria-current="page"><%= link_to @proposal.proposal_type.name, edit_proposal_path(@proposal) %></li>
@@ -73,7 +73,7 @@
                               Please list all the changes you have made to your proposal here.
                             </p>
                             <p>
-                              For example, you could say, "As requested by the BIRS program committee, we have increased our number of early-career participants by inviting the following people ... ". 
+                              For example, you could say, "As requested by the BIRS program committee, we have increased our number of early-career participants by inviting the following people ... ".
                             </p>
                             <%= f.text_area(:cover_letter, size: '5x5', class:'form-control', value: @proposal&.cover_letter, disabled: action) %>
                           </div>
@@ -81,7 +81,7 @@
                         <div class="mb-3">
                           <p><%= @proposal.proposal_form.introduction&.html_safe %></p>
                         </div>
-                        <% if @proposal.code.present? && params[:action] == 'show' %> 
+                        <% if @proposal.code.present? && params[:action] == 'show' %>
                           <div class="mb-3">
                             <p>Code: <%= @proposal.code %></p>
                           </div>
@@ -108,7 +108,7 @@
                           <div class="mb-3">
                             <%= f.text_field :assigned_size, class: 'form-control w-25', disabled: true, value: @proposal.assigned_size %>
                           </div>
-                          <div class="mb-3">  
+                          <div class="mb-3">
                             <%= label_tag :applied_date %>
                             <%= f.text_field :applied_date, class: 'form-control w-25', disabled: true, value: @proposal.applied_date %>
                           </div>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -6,7 +6,7 @@
       </h1>
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
-          <li class="breadcrumb-item"><%= link_to "Dashboard", dashboards_path %> </a></li>
+          <li class="breadcrumb-item"><%= link_to "Dashboard", dashboards_path %></li>
           <li class="breadcrumb-item active" aria-current="page"><%= link_to "Proposals", proposals_path %></li>
         </ol>
       </nav>

--- a/app/views/proposals/new.html.erb
+++ b/app/views/proposals/new.html.erb
@@ -22,11 +22,11 @@
                 <div class="col-lg-8">
                   <div class="mb-3">
                     <%= f.label :proposal_types, "Select the type of proposal to create:", class: 'form-label' %>
-                    <%= f.select :proposal_type_id, options_for_select(proposal_types), {}, { class: 'form-select w-50',  data: { action: 'change->submit-proposals#fillProposalYears' } } %>
+                    <%= f.select :proposal_type_id, options_for_select(proposal_types), { include_blank: true }, { class: 'form-select w-50', required: true, data: { action: 'change->submit-proposals#fillProposalYears' } } %>
                   </div>
                   <div class="mb-3">
                     <%= f.label :year %>
-                    <%= f.select :year, [], {}, { class: "form-select w-25", data: { 'submit-proposals_target' => 'yearSelect' } } %>
+                    <%= f.select :year, [], {}, { class: "form-select w-25", required: true, data: { 'submit-proposals_target' => 'yearSelect' } } %>
                   </div>
                   <div class="form-group">
                     <%= f.submit 'Submit', class:'btn btn-primary' %>

--- a/app/views/proposals/new.html.erb
+++ b/app/views/proposals/new.html.erb
@@ -6,7 +6,7 @@
       </h1>
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
-           <li class="breadcrumb-item"> <%= link_to "Dashboard", dashboards_path %> </a></li>
+           <li class="breadcrumb-item"> <%= link_to "Dashboard", dashboards_path %></li>
           <li class="breadcrumb-item active" aria-current="page"><%= link_to "Proposals", proposals_path %></li>
           <li class="breadcrumb-item active" aria-current="page">New</li>
         </ol>
@@ -18,11 +18,15 @@
           <div class="card-body">
             <div data-controller="submit-proposals">
               <h2>Start a New Proposal Application</h2>
-              <%= form_for @proposal do  |f| %>
+              <%= form_for @proposal do |f| %>
                 <div class="col-lg-8">
                   <div class="mb-3">
                     <%= f.label :proposal_types, "Select the type of proposal to create:", class: 'form-label' %>
-                    <%= f.select :proposal_type_id, options_for_select(proposal_types), {}, class: 'form-select w-50' %>
+                    <%= f.select :proposal_type_id, options_for_select(proposal_types), {}, { class: 'form-select w-50',  data: { action: 'change->submit-proposals#fillProposalYears' } } %>
+                  </div>
+                  <div class="mb-3">
+                    <%= f.label :year %>
+                    <%= f.select :year, [], {}, { class: "form-select w-25", data: { 'submit-proposals_target' => 'yearSelect' } } %>
                   </div>
                   <div class="form-group">
                     <%= f.submit 'Submit', class:'btn btn-primary' %>

--- a/app/views/proposals/proposal_version.html.erb
+++ b/app/views/proposals/proposal_version.html.erb
@@ -6,7 +6,7 @@
       </h1>
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb" data-turbo="false">
-          <li class="breadcrumb-item"> <%= link_to "Dashboard", dashboards_path %> </a></li>
+          <li class="breadcrumb-item"> <%= link_to "Dashboard", dashboards_path %></li>
           <% if current_user.staff_member? %>
             <li class="breadcrumb-item active" aria-current="page"><%= link_to "Submitted Proposals", submitted_proposals_path %></li>
           <% else %>
@@ -28,7 +28,7 @@
                 data-nested-invites-max-participant-value="<%= @proposal.proposal_type.participant %>"
                 data-nested-invites-max-organizer-value="<%= @proposal.proposal_type.co_organizer %>"
                 data-nested-invites-organizer-value="<%= confirmed_participants(@proposal.id, 'Organizer').count %>"
-                data-nested-invites-participant-value="<%= confirmed_participants(@proposal.id, 'Participant').count %>" 
+                data-nested-invites-participant-value="<%= confirmed_participants(@proposal.id, 'Participant').count %>"
               >
               <input type="hidden" name="version" data-submit-proposals-target="proposalVersion" value="<%= @version %>" id="proposal_version">
                 <div class="col-12 col-lg-12">
@@ -57,7 +57,7 @@
                               Please list all the changes you have made to your proposal here.
                             </p>
                             <p>
-                              For example, you could say, "As requested by the BIRS program committee, we have increased our number of early-career participants by inviting the following people ... ". 
+                              For example, you could say, "As requested by the BIRS program committee, we have increased our number of early-career participants by inviting the following people ... ".
                             </p>
                             <%= f.text_area(:cover_letter, size: '5x5', class:'form-control', value: @proposal&.cover_letter, disabled: action) %>
                           </div>
@@ -230,7 +230,7 @@
                           <button id="changeTab" class="p-2 btn btn-primary" data-action='click->submit-proposals#nextTab'>Next</button>
                          </div>
                       </div>
-                      
+
                       <div class="tab-pane" id="tab-3" role="tabpanel">
                         <div class="mb-3">
                           <p><%= @proposal.proposal_form.introduction3&.html_safe %></p>
@@ -365,11 +365,12 @@
                     </div>
                   </div>
                 </div>
-              </div> 
+              </div>
             </div>
           </div>
         </div>
       </div>
+    </div>
   </div>
 </main>
 

--- a/app/views/submit_proposals/new.html.erb
+++ b/app/views/submit_proposals/new.html.erb
@@ -6,7 +6,7 @@
       </h1>
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
-           <li class="breadcrumb-item"> <%= link_to "Dashboard", dashboards_path %> </a></li>
+           <li class="breadcrumb-item"> <%= link_to "Dashboard", dashboards_path %></li>
           <li class="breadcrumb-item active" aria-current="page">Proposals</li>
           <li class="breadcrumb-item active" aria-current="page">New</li>
         </ol>
@@ -16,7 +16,7 @@
       <div class="col-12">
         <div class="card">
           <div class="card-body">
-            <div data-controller="submit-proposals">  
+            <div data-controller="submit-proposals">
                 <%= form_with url: submit_proposals_path do  |f| %>
                   <fieldset class="mt-8"></fieldset>
                     <legend>Basic</legend>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
       invites:
         invalid_code: This invitation code is invalid
       something_went_wrong: 'Something went wrong.'
+      resource_not_found: 'Requested resource not found'
       email_verifier:
         email_not_real: must point to a real mail account
         out_of_mail_server: appears to point to dead mail server

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
     messages:
       invites:
         invalid_code: This invitation code is invalid
+      something_went_wrong: 'Something went wrong.'
       email_verifier:
         email_not_real: must point to a real mail account
         out_of_mail_server: appears to point to dead mail server

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,6 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
   errors:
     messages:
       invites:
@@ -41,3 +40,6 @@ en:
         no_mail_server: appears to point to domain which doesn't handle e-mail
         failure:  delivery failed! The email you have entered not found.
         exception: could not be sent
+  proposals:
+    initialize: 'Started a new %{proposal_type} proposal!'
+    limit_per_type_per_year: 'There is a limit of one %{proposal_type} proposal per year.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
     collection do
       get :thanks
       post :invitation_template
+      post :create_invite
     end
   end
   resources :proposal_types do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,7 @@ Rails.application.routes.draw do
     member do
       get :location_based_fields
       get :proposal_type_locations
+      get :years
     end
   end
   resources :locations do

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -9,7 +9,6 @@ environment.plugins.prepend('Provide',
     'window.jQuery': 'jquery/src/jquery',
     jQuery: 'jquery/src/jquery',
     Popper: ['popper.js', 'default'],
-    'window.Turbo': 'Turbo',
   })
 )
 

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -8,7 +8,8 @@ environment.plugins.prepend('Provide',
     jquery: 'jquery/src/jquery',
     'window.jQuery': 'jquery/src/jquery',
     jQuery: 'jquery/src/jquery',
-    Popper: ['popper.js', 'default']
+    Popper: ['popper.js', 'default'],
+    'window.Turbo': 'Turbo',
   })
 )
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.3",
+    "@hotwired/turbo": "^7.3.0",
     "@hotwired/turbo-rails": "^7.0.0-beta.5",
     "@popperjs/core": "2.9.2",
     "@rails/actioncable": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/actioncable": "^6.0.0",
     "@rails/actiontext": "^6.1.4",
     "@rails/activestorage": "^6.0.0",
+    "@rails/request.js": "^0.0.8",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.4",
     "@yaireo/tagify": "^4.8.1",

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :role do
     name { 'Admin' }
+    role_type { :staff_role }
   end
 end

--- a/spec/factories/user_roles.rb
+++ b/spec/factories/user_roles.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user_role do
-    association :user, factory: user
-    association :role, factory: role
+    association :user, factory: :user
+    association :role, factory: :role
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,5 +7,13 @@ FactoryBot.define do
     f.password { password }
     f.password_confirmation { password }
     f.confirmed_at { Time.current }
+
+    trait :with_privilege do
+      after(:create) do |user, options|
+        user_role = create(:user_role, user: user)
+        privilege_name = options[:privilege_name] || 'SubmitProposalsController'
+        create(:role_privilege, permission_type: 'Manage', privilege_name: privilege_name, role: user_role.role)
+      end
+    end
   end
 end

--- a/spec/features/proposal_edit_spec.rb
+++ b/spec/features/proposal_edit_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Proposal edit", type: :feature do
   end
 
   scenario "there is a Year field containing the year" do
-    expect(page).to have_select('year', options: @proposal.proposal_type.year.split(','))
+    expect(page).to have_select('year', options: [''] + @proposal.proposal_type.year.split(','))
   end
 
   context "Subject Areas" do

--- a/spec/features/proposal_edit_spec.rb
+++ b/spec/features/proposal_edit_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Proposal edit", type: :feature do
   end
 
   scenario "there is a Year field containing the year" do
-    expect(page).to have_select('year', options: [''] + @proposal.proposal_type.year.split(','))
+    expect(page).to have_select('year', options: [''] + proposal.proposal_type.year.split(','))
   end
 
   context "Subject Areas" do

--- a/spec/features/proposal_edit_spec.rb
+++ b/spec/features/proposal_edit_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Proposal edit", type: :feature do
   end
 
   scenario "there is a Year field containing the year" do
-    expect(page).to have_select('year', options: [''] + proposal.proposal_type.year.split(','))
+    expect(page).to have_select('year', options: [''] + @proposal.proposal_type.year.split(','))
   end
 
   context "Subject Areas" do

--- a/spec/features/proposal_new_spec.rb
+++ b/spec/features/proposal_new_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "Proposal New", type: :feature do
+RSpec.describe "Proposal New", type: :feature do
   before do
     proposal_type = create(:proposal_type)
     create(:proposal_form, status: :active, proposal_type: proposal_type)
@@ -14,7 +14,8 @@ RSpec.feature "Proposal New", type: :feature do
     end
   end
 
-  scenario "creating a new proposal " do
+  # TODO: fix after adding selenium webdriver to capybara
+  pending "creating a new proposal " do
     find('input[name="commit"]').click
     expect(Proposal.count).to eq(1)
     expect(page).to have_current_path(edit_proposal_path(Proposal.last))

--- a/spec/requests/submit_proposals_spec.rb
+++ b/spec/requests/submit_proposals_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe "/submit_proposals", type: :request do
+  let(:proposal_type) { create(:proposal_type) }
+  let(:proposal) { create(:proposal, proposal_type: proposal_type) }
+  let(:subject_category) { create(:subject_category) }
+  let(:subject) { create(:subject, subject_category_id: subject_category.id) }
+  let(:ams_subjects) do
+    create_list(:ams_subject, 2, subject_category_ids: subject_category.id,
+                subject_id: subject.id)
+  end
+  let(:location) { create(:location) }
+
   before do
     person = create(:person, :with_proposals)
     prop = person.proposals.first
@@ -8,23 +18,12 @@ RSpec.describe "/submit_proposals", type: :request do
     expect(person.user.lead_organizer?(prop)).to be_truthy
   end
 
-  let(:proposal_type) { create(:proposal_type) }
-  let(:proposal) { create(:proposal, proposal_type: proposal_type) }
-
   describe "GET /new" do
     before { get new_submit_proposal_path }
     it { expect(response).to have_http_status(:ok) }
   end
 
   describe "POST /create without invite" do
-    let(:proposal) { create(:proposal) }
-    let(:subject_category) { create(:subject_category) }
-    let(:subject) { create(:subject, subject_category_id: subject_category.id) }
-    let(:ams_subjects) do
-      create_list(:ams_subject, 2, subject_category_ids: subject_category.id,
-                                   subject_id: subject.id)
-    end
-    let(:location) { create(:location) }
     let(:invites_attributes) do
       {
         '0' => { firstname: 'First', lastname: 'Organizer',
@@ -32,16 +31,23 @@ RSpec.describe "/submit_proposals", type: :request do
       }
     end
 
-    let(:person) { create(:person) }
-    let(:role) { create(:role, name: 'Staff') }
-    let(:user) { create(:user, person: person) }
+    let(:person) { user.person }
+    let(:role) { user_role.role }
+    let(:user_role) { create(:user_role, role: create(:role, name: role_name)) }
+    let(:proposal_role) { create(:proposal_role, role: role, proposal: proposal, person: person) }
+    let(:role_name) { 'Staff' }
+    let(:user) { user_role.user }
     let(:role_privilege) do
       create(:role_privilege,
-             permission_type: "Manage", privilege_name: "SubmitProposalsController", role_id: role.id)
+             permission_type: 'Manage', privilege_name: 'SubmitProposalsController', role_id: role.id)
+      create(:role_privilege,
+             permission_type: 'Manage', privilege_name: 'SubmittedProposalsController', role_id: role.id)
+      create(:role_privilege,
+             permission_type: 'Manage', privilege_name: 'ProposalsController', role_id: role.id)
     end
 
     let(:params) do
-      { proposal: proposal.id, title: 'Test proposal', year: '2023', assigned_date: Date.today.to_date, applied_date: Date.today.to_date,
+      { proposal: proposal.id, title: 'Test proposal', year: '2023', assigned_date: Date.today, applied_date: Date.today,
         subject_id: subject.id,
         ams_subjects: { code1: ams_subjects.first.id,
                         code2: ams_subjects.last.id },
@@ -50,31 +56,60 @@ RSpec.describe "/submit_proposals", type: :request do
     end
 
     before do
+      proposal_role
       role_privilege
-      user.roles << role
       sign_in user
 
       post submit_proposals_url, params: params, xhr: true
     end
 
-    it "updates the proposal but will not create invite" do
+    describe 'redirects' do
+      context 'when staff' do
+        let(:role_name) { 'Staff' }
+
+        it { expect(response).to redirect_to(submitted_proposals_path) }
+      end
+
+      context 'when lead organizer' do
+        let(:role_name) { 'lead_organizer' }
+
+        it { expect(response).to redirect_to(edit_proposal_path(proposal)) }
+      end
+    end
+
+    it 'will not create invite' do
       expect(proposal.invites.count).to eq(0)
+    end
+
+    it 'updates the proposal' do
+      proposal.reload
+      expect(proposal.title).to eq('Test proposal')
+      expect(proposal.year).to eq('2023')
+      expect(proposal.assigned_date).to eq(Date.today)
+      expect(proposal.applied_date).to eq(Date.today)
+      expect(proposal.subject_id).to eq(subject.id)
+      expect(proposal.location_ids).to eq([location.id])
+      expect(proposal.ams_subjects).to eq(ams_subjects)
+      expect(proposal.no_latex).to eq(false)
+    end
+
+    context 'when user exhausts proposal type per year limit' do
+      let(:role_name) { 'lead_organizer' }
+      let(:old_proposal) { create(:proposal, proposal_type: proposal.proposal_type, year: params[:year]) }
+
+      before do
+        create(:proposal_role, proposal: old_proposal, role: role, person: user.person)
+
+        post submit_proposals_url, params: params
+      end
+
+      it 'will alert' do
+        expect(flash[:alert]).to eq([I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)])
+      end
     end
   end
 
   describe "POST /create with invite parameters" do
-    let(:proposal) { create(:proposal) }
-    let(:subject_category) { create(:subject_category) }
-    let(:subject) { create(:subject, subject_category_id: subject_category.id) }
-    let(:ams_subject_code1) do
-      create(:ams_subject, subject_category_ids:
-                           subject_category.id, subject_id: subject.id)
-    end
-    let(:ams_subject_code2) do
-      create(:ams_subject, subject_category_ids:
-                           subject_category.id, subject_id: subject.id)
-    end
-    let(:location) { create(:location) }
     let(:invites_attributes) do
       { '0' => { firstname: 'First', lastname: 'Organizer',
                  email: 'organizer@gmail.com', deadline_date: DateTime.now,
@@ -82,10 +117,11 @@ RSpec.describe "/submit_proposals", type: :request do
     end
     let(:params) do
       { proposal: proposal.id, title: 'Test proposal', year: '2023',
-        subject_id: subject.id, ams_subjects: { code1: ams_subject_code1.id, code2: ams_subject_code2.id },
+        subject_id: subject.id, ams_subjects: { code1: ams_subjects.first.id, code2: ams_subjects.second.id },
         invites_attributes: invites_attributes,
-        location_ids: location.id, no_latex: false, create_invite: true }
+        location_ids: location.id, no_latex: false, create_invite: create_invite }
     end
+    let(:create_invite) { true }
 
     context 'with valid invite params, as lead organizer' do
       let!(:proposal) { build :proposal, proposal_type: proposal_type, is_submission: true}
@@ -106,8 +142,9 @@ RSpec.describe "/submit_proposals", type: :request do
     end
 
     context 'with valid invite params, as lead organizer and false create_invite' do
+      let(:create_invite) { false }
+
       before do
-        params[:create_invite] = false
         @prop = @person.proposals.first
         expect(@person.user.lead_organizer?(@prop)).to be_truthy
         @invites_count = @prop.invites.count
@@ -122,8 +159,9 @@ RSpec.describe "/submit_proposals", type: :request do
     end
 
     context 'with valid invite params, as lead organizer and nil create_invite' do
+      let(:create_invite) { nil }
+
       before do
-        params[:create_invite] = nil
         @prop = @person.proposals.first
         expect(@person.user.lead_organizer?(@prop)).to be_truthy
         @invites_count = @prop.invites.count
@@ -186,6 +224,7 @@ RSpec.describe "/submit_proposals", type: :request do
 
   describe "POST /invitation_template" do
     let(:proposal_role) { create(:proposal_role, proposal: proposal) }
+
     context "when params contain organizer" do
       let(:params) do
         {

--- a/spec/requests/submit_proposals_spec.rb
+++ b/spec/requests/submit_proposals_spec.rb
@@ -114,7 +114,8 @@ RSpec.describe "/submit_proposals", type: :request do
       end
 
       it 'will alert' do
-        expect(flash[:alert]).to eq([I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)])
+        expect(flash[:alert])
+          .to eq(["Year #{I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)}"])
       end
     end
   end

--- a/spec/requests/submit_proposals_spec.rb
+++ b/spec/requests/submit_proposals_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe "/submit_proposals", type: :request do
       role_privilege
       user.roles << role
       sign_in user
+
       post submit_proposals_url, params: params, xhr: true
     end
 
@@ -143,7 +144,7 @@ RSpec.describe "/submit_proposals", type: :request do
       it "does not update the proposal invites count" do
         expect(proposal.invites.count).to eq(0)
       end
-    end 
+    end
 
     context 'with invalid invite params, as lead organizer' do
       before do

--- a/spec/services/proposals/initialize_spec.rb
+++ b/spec/services/proposals/initialize_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Proposals::Initialize do
+  subject(:service_call) { described_class.call(current_user: user, proposal_params: params) }
+
+  let(:user) { create(:user) }
+  let(:proposal_form) { create(:proposal_form, status: 'active', proposal_type: proposal_type) }
+  let(:proposal_type) { create(:proposal_type) }
+  let(:params) { { proposal_type_id: proposal_type.id } }
+  let(:proposal) { service_call.proposal }
+
+  describe '.call' do
+    before do
+      proposal_form
+    end
+
+    it 'creates proposal' do
+      expect(service_call.proposal).to be_persisted
+    end
+
+    it 'has no error' do
+      expect(service_call.errors?).to be_falsey
+    end
+
+    it 'has redirect url to edit path' do
+      expect(service_call.redirect_url).to eq("/proposals/#{proposal.id}/edit")
+    end
+
+    it 'has notice' do
+      expect(service_call.flash_message[:notice]).to eq(I18n.t('proposals.initialize', proposal_type: proposal_type.name))
+    end
+
+    context 'when error' do
+      before do
+        allow_any_instance_of(described_class).to receive(:ensure_organizer_role).and_raise(StandardError)
+      end
+
+      it 'does not create proposal' do
+        expect(service_call.proposal).not_to be_persisted
+      end
+
+      it 'has error' do
+        expect(service_call.errors?).to be_truthy
+      end
+
+      it 'has redirect url to new proposal path' do
+        expect(service_call.redirect_url).to eq("/proposals/new")
+      end
+
+      it 'has alert' do
+        expect(service_call.flash_message[:alert]).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/proposals/update_spec.rb
+++ b/spec/services/proposals/update_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Proposals::Update do
 
       it 'has error message' do
         expect(service_call.flash_message[:alert])
-          .to eq([I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)])
+          .to eq(["Year #{I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)}"])
       end
 
       it 'updates attributes except year' do

--- a/spec/services/proposals/update_spec.rb
+++ b/spec/services/proposals/update_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Proposals::Update do
+  subject(:service_call) { described_class.call(current_user: user, proposal: proposal, params: params) }
+
+  let(:user) { create(:user) }
+  let(:proposal) { create(:proposal) }
+
+  let(:params) { { title: 'New title', year: Date.today.year } }
+
+  describe '.call' do
+    it 'has no errors' do
+      expect(service_call.errors?).to be_falsey
+    end
+
+    it 'updates proposal' do
+      service_call
+      proposal.reload
+
+      expect(proposal.title).to eq(params[:title])
+      expect(proposal.year).to eq(params[:year].to_s)
+    end
+
+    context 'proposal per type per year limit exceeded' do
+      let(:role) { create(:role, name: 'lead_organizer') }
+      let(:old_proposal) { create(:proposal, proposal_type: proposal.proposal_type, year: params[:year]) }
+
+      before do
+        create(:proposal_role, proposal: old_proposal, role: role, person: user.person)
+      end
+
+      it 'has error' do
+        expect(service_call.errors?).to be_truthy
+      end
+
+      it 'has error message' do
+        expect(service_call.flash_message[:alert])
+          .to eq([I18n.t('proposals.limit_per_type_per_year', proposal_type: proposal.proposal_type.name)])
+      end
+
+      it 'updates attributes except year' do
+        service_call
+        proposal.reload
+
+        expect(proposal.title).to eq(params[:title])
+        expect(proposal.year).not_to eq(params[:year])
+      end
+    end
+  end
+end

--- a/spec/services/proposals/update_spec.rb
+++ b/spec/services/proposals/update_spec.rb
@@ -48,5 +48,15 @@ RSpec.describe Proposals::Update do
         expect(proposal.year).not_to eq(params[:year])
       end
     end
+
+    context 'when error' do
+      before do
+        allow_any_instance_of(described_class).to receive(:first_ams_subject_id).and_return(1)
+      end
+
+      it 'shows error' do
+        expect(service_call.flash_message[:alert]).to eq(['Validation failed: Ams subject must exist'])
+      end
+    end
   end
 end

--- a/spec/services/proposals/update_spec.rb
+++ b/spec/services/proposals/update_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe Proposals::Update do
 
     context 'proposal per type per year limit exceeded' do
       let(:role) { create(:role, name: 'lead_organizer') }
-      let(:old_proposal) { create(:proposal, proposal_type: proposal.proposal_type, year: params[:year]) }
+      let(:old_proposal) do
+        create(:proposal, proposal_type: proposal.proposal_type, year: params[:year], status: :submitted)
+      end
 
       before do
         create(:proposal_role, proposal: old_proposal, role: role, person: user.person)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,6 +1088,11 @@
   dependencies:
     spark-md5 "^3.0.0"
 
+"@rails/request.js@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.8.tgz#5e2e8da15013b1af7f04d759e4e9d1cff981865c"
+  integrity sha512-ysHYZDl+XjBwFVXz7EI7XW+ZWiTFY8t7TrC/ahpAPt0p7NE4DZxm1nJQY9gmF4PBf+4pAYa+D/rLIGmrn1ZMvg==
+
 "@rails/ujs@^6.0.0":
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.3.tgz#90ef26caa0925492b1a3b1495db09cfbe49e745e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,6 +1056,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@hotwired/turbo@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.3.0.tgz#2226000fff1aabda9fd9587474565c9929dbf15d"
+  integrity sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==
+
 "@npmcli/move-file@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674"


### PR DESCRIPTION
This PR is an overhaul of create/update actions for Proposal model. 

* It introduces two new services `Proposals::Initialize` and `Proposals::Update`. 
* Adds a validation class to validate the year in `Proposals::Initialize`, `Proposals::Update`. Because it involves a heavy query, I've decided not to add it to Proposal model, and instead validate year manually inside service.
* Makes so that `/proposals/new` page has a year dropdown.