### PR TITLE
Fix inviting participants/members before saving proposal

### DIFF
--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -61,6 +61,7 @@ class SubmitProposalsController < ApplicationController
 
   def invite_save
     return unless @invite.save
+
     log_activity(@invite)
     @counter += 1
   end
@@ -177,13 +178,14 @@ class SubmitProposalsController < ApplicationController
     if @template_body.blank?
       return redirect_to new_email_template_path, alert: t('submit_proposals.preview_placeholders.failure')
     end
+
     placing_holders
   end
 
   def placing_holders
-    placeholders = { "Proposal_lead_organizer_name" => @proposal&.lead_organizer&.fullname,
-                     "proposal_type" => @proposal.proposal_type&.name,
-                     "proposal_title" => @proposal&.title }
+    placeholders = { "Proposal_lead_organizer_name" => @proposal&.lead_organizer&.fullname.to_s,
+                     "proposal_type" => @proposal.proposal_type&.name.to_s,
+                     "proposal_title" => @proposal&.title.to_s }
     placeholders.each { |k, v| @template_body&.gsub!(k, v) }
   end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -148,8 +148,9 @@ class Proposal < ApplicationRecord
   end
 
   def demographics_data
-    DemographicData.where(person_id: invites.where(invited_as: 'Participant')
-                   .pluck(:person_id))
+    @demographic_data ||= DemographicData
+      .where(person_id: invites.where(invited_as: 'Participant')
+      .pluck(:person_id))
   end
 
   def invites_demographic_data

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
   end
 
   def staff_member?
-    roles.exists?(name: 'Staff')
+    @staff_member ||= roles.exists?(name: 'Staff')
   end
 
   def organizer?(proposal)

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -89,13 +89,13 @@ module Proposals
     end
 
     def update_ams_subject_codes
-      if first_ams_subject_id
+      if first_ams_subject_id.present?
         first_ams_subject = ProposalAmsSubject.find_or_initialize_by(proposal: proposal, code: 'code1')
         first_ams_subject.ams_subject_id = first_ams_subject_id
         first_ams_subject.save!
       end
 
-      if second_ams_subject_id
+      if second_ams_subject_id.present?
         second_ams_subject = ProposalAmsSubject.find_or_initialize_by(proposal: proposal, code: 'code2')
         second_ams_subject.ams_subject_id = second_ams_subject_id
         second_ams_subject.save!

--- a/app/services/proposals/update.rb
+++ b/app/services/proposals/update.rb
@@ -44,9 +44,9 @@ module Proposals
     end
 
     def initialize(current_user:, proposal:, params:)
-      @current_user = current_user
       @proposal = proposal
       @params = params
+      @current_user = find_performing_user(current_user)
     end
 
     def call
@@ -116,6 +116,17 @@ module Proposals
 
     def submission
       @submission ||= SubmitProposalService.new(proposal, params)
+    end
+
+    def find_performing_user(user)
+      lead_organizer = @proposal.lead_organizer
+
+      # Since staff can edit proposals use lead organizer as performing user when appropriate
+      if lead_organizer.present? && user.staff_member?
+        lead_organizer.user
+      else
+        user
+      end
     end
   end
 end

--- a/app/validators/upsert_proposal_validator.rb
+++ b/app/validators/upsert_proposal_validator.rb
@@ -8,11 +8,9 @@ module UpsertProposalValidator
     validate
     rollback_invalid_attributes
 
-    if validation_errors? && halt_on_error
-      raise ActiveRecord::RecordInvalid
-    else
-      proposal.save
-    end
+    raise ActiveRecord::RecordInvalid if validation_errors? && halt_on_error
+
+    proposal.save
   ensure
     populate_errors
   end

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -34,7 +34,8 @@
             <div class="card-body">
               <div data-controller="submit-proposals proposal-form nested-invites"
                 data-submit-proposals-proposal-type-id-value="<%= @proposal.proposal_type.id %>"
-                data-submit-proposals-proposal-value="<%= @proposal.id %>"data-nested-invites-wrapper-selector-value=".nested-invites-wrapper"
+                data-submit-proposals-proposal-value="<%= @proposal.id %>"
+                data-nested-invites-wrapper-selector-value=".nested-invites-wrapper"
                 data-nested-invites-max-participant-value="<%= @proposal.proposal_type.participant %>"
                 data-nested-invites-max-organizer-value="<%= @proposal.proposal_type.co_organizer %>"
                 data-nested-invites-organizer-value="<%= confirmed_participants(@proposal.id, 'Organizer').count %>"
@@ -162,68 +163,75 @@
                         </div>
                           <div>
                             <% if params[:action] == 'edit' %>
-                            <%= render partial: 'lead_organizer' %>
-                            <div>
-                              <h3 class="form-section">Add Supporting Organizers:</h3>
-                              <p><%= @proposal.proposal_type.organizer_description&.html_safe %></p>
-                              <% if @proposal.invites.organizer %>
-                                <%= render partial: 'organizer', locals: { invites: @proposal.invites.organizer } %>
-                              <% end %>
+                              <%= render partial: 'lead_organizer' %>
+                              <% @has_title = @proposal.title.present? %>
                               <div>
-                                <% if max_invitations(@proposal, 'Organizer') %>
-                                  <% date = @proposal.invites.where(invited_as: 'Organizer').first&.deadline_date&.to_date %>
-                                    <% unless date.nil? %>
-                                      <% date = date  < DateTime.current.to_date ? DateTime.current.to_date : @proposal.invites.where(invited_as: 'Organizer').first&.deadline_date&.to_date %>
-                                    <% end %>
-                                  <div class="mb-3">
-                                    <template data-nested-invites-target="template">
-                                      <%= f.fields_for :invites, Invite.new, child_index: 'NEW_RECORD' do |invite| %>
-                                        <%= render partial: 'invite', locals: { f: invite, invited_as: 'Organizer', date: date } %>
-                                      <% end %>
-                                    </template>
-                                    <div data-nested-invites-target="target"></div>
-                                      <button type="button" class="btn btn-light" data-action="nested-invites#addOrganizers" id="add-more-organizer">
-                                        Queue More Organizer Invitations
-                                      </button>
-                                  </div>
-                                  <div class="mb-3">
-                                    <button id="organizer" data-action="click->nested-invites#invitePreview" data-id="<%= @proposal.id %>" class="btn btn-primary">Invite Organizer(s)</button>
-                                  </div>
+                                <h3 class="form-section">Add Supporting Organizers:</h3>
+                                <% unless @has_title %>
+                                  <p class="field-validation">Please, fill in title and save before proceeding</p>
                                 <% end %>
-                              </div>
-                            </div>
-                            <div class="mt-4">
-                              <div class="mb-3">
-                                <h3 class="form-section">Add Participants:</h3>
-                                <p><%= @proposal.proposal_type.participant_description&.html_safe %></p>
-
-                                <% if @proposal.invites.participant %>
-                                  <%= render partial: 'organizer', locals: { invites: @proposal.invites.participant } %>
+                                <p><%= @proposal.proposal_type.organizer_description&.html_safe %></p>
+                                <% if @proposal.invites.organizer %>
+                                  <%= render partial: 'organizer', locals: { invites: @proposal.invites.organizer } %>
                                 <% end %>
                                 <div>
-                                  <% if max_invitations(@proposal, 'Participant') %>
-                                    <% date = @proposal.invites.where(invited_as: 'Participant').first&.deadline_date&.to_date %>
-                                    <% unless date.nil? %>
-                                      <% date = date < DateTime.current.to_date ? DateTime.current.to_date : @proposal.invites.where(invited_as: 'Participant').first&.deadline_date&.to_date %>
-                                    <% end %>
+                                  <% if max_invitations(@proposal, 'Organizer') %>
+                                    <% date = @proposal.invites.where(invited_as: 'Organizer').first&.deadline_date&.to_date %>
+                                      <% unless date.nil? %>
+                                        <% date = date  < DateTime.current.to_date ? DateTime.current.to_date : @proposal.invites.where(invited_as: 'Organizer').first&.deadline_date&.to_date %>
+                                      <% end %>
                                     <div class="mb-3">
-                                      <template data-nested-invites-target="templateOne">
+                                      <template data-nested-invites-target="template">
                                         <%= f.fields_for :invites, Invite.new, child_index: 'NEW_RECORD' do |invite| %>
-                                          <%= render partial: 'invite', locals: { f: invite, invited_as: 'Participant', date: date } %>
+                                          <%= render partial: 'invite', locals: { f: invite, invited_as: 'Organizer', date: date } %>
                                         <% end %>
                                       </template>
-                                      <div data-nested-invites-target="targetOne"></div>
-                                        <button type="button" class="btn btn-light" data-action="nested-invites#addParticipants" id="add-more-participant">
-                                          Queue More Participant Invitations
-                                        </button>
+                                      <div data-nested-invites-target="target"></div>
+                                      <button type="button" class="btn btn-light" data-action="nested-invites#addOrganizers" id="add-more-organizer" <%= @has_title ? '' : 'disabled' %>>
+                                        Queue More Organizer Invitations
+                                      </button>
                                     </div>
                                     <div class="mb-3">
-                                      <button id="participant" data-action="click->nested-invites#invitePreview" data-id="<%= @proposal.id %>" class="btn btn-primary">Invite Participant(s)</button>
+                                      <button id="organizer" data-action="click->nested-invites#invitePreview" data-id="<%= @proposal.id %>" class="btn btn-primary" <%= @has_title ? '' : 'disabled' %>>Invite Organizer(s)</button>
                                     </div>
                                   <% end %>
                                 </div>
                               </div>
-                            </div>
+                              <div class="mt-4">
+                                <div class="mb-3">
+                                  <h3 class="form-section">Add Participants:</h3>
+                                  <% unless @has_title %>
+                                    <p class="field-validation">Please, fill in title and save before proceeding</p>
+                                  <% end %>
+                                  <p><%= @proposal.proposal_type.participant_description&.html_safe %></p>
+
+                                  <% if @proposal.invites.participant %>
+                                    <%= render partial: 'organizer', locals: { invites: @proposal.invites.participant } %>
+                                  <% end %>
+                                  <div>
+                                    <% if max_invitations(@proposal, 'Participant') %>
+                                      <% date = @proposal.invites.where(invited_as: 'Participant').first&.deadline_date&.to_date %>
+                                      <% unless date.nil? %>
+                                        <% date = date < DateTime.current.to_date ? DateTime.current.to_date : @proposal.invites.where(invited_as: 'Participant').first&.deadline_date&.to_date %>
+                                      <% end %>
+                                      <div class="mb-3">
+                                        <template data-nested-invites-target="templateOne">
+                                          <%= f.fields_for :invites, Invite.new, child_index: 'NEW_RECORD' do |invite| %>
+                                            <%= render partial: 'invite', locals: { f: invite, invited_as: 'Participant', date: date } %>
+                                          <% end %>
+                                        </template>
+                                        <div data-nested-invites-target="targetOne"></div>
+                                        <button type="button" class="btn btn-light" data-action="nested-invites#addParticipants" id="add-more-participant" <%= @has_title ? '' : 'disabled' %>>
+                                          Queue More Participant Invitations
+                                        </button>
+                                      </div>
+                                      <div class="mb-3">
+                                        <button id="participant" data-action="click->nested-invites#invitePreview" data-id="<%= @proposal.id %>" class="btn btn-primary" <%= @has_title ? '' : 'disabled' %>>Invite Participant(s)</button>
+                                      </div>
+                                    <% end %>
+                                  </div>
+                                </div>
+                              </div>
                             <% end %>
                             <% if params[:action] == 'show' %>
                               <div>

--- a/spec/features/proposal_edit_spec.rb
+++ b/spec/features/proposal_edit_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Proposal edit", type: :feature do
   end
 
   scenario "there is a Year field containing the year" do
-    expect(page).to have_select('year', options: [''] + @proposal.proposal_type.year.split(','))
+    expect(page).to have_select('year', options: [''] + proposal.proposal_type.year.split(','))
   end
 
   context "Subject Areas" do

--- a/spec/features/proposal_edit_spec.rb
+++ b/spec/features/proposal_edit_spec.rb
@@ -1,22 +1,22 @@
 require 'rails_helper'
 
 RSpec.feature "Proposal edit", type: :feature do
-  before do
-    person = create(:person, :with_proposals)
-    @proposal = person.proposals.first
+  let(:person) { create(:person, :with_proposals) }
+  let(:proposal) { person.proposals.first }
 
+  before do
     authenticate_user(person)
-    expect(person.user.lead_organizer?(@proposal)).to be_truthy
-    visit edit_proposal_path(@proposal)
+    expect(person.user.lead_organizer?(proposal)).to be_truthy
+    visit edit_proposal_path(proposal)
   end
 
   scenario "there is a Title field containing the title" do
-    expect(current_path).to eq(edit_proposal_path(@proposal))
-    expect(find_field('title').value).to eq(@proposal.title)
+    expect(current_path).to eq(edit_proposal_path(proposal))
+    expect(find_field('title').value).to eq(proposal.title)
   end
 
   scenario "there is a Type of Meeting field containing the type of meeting" do
-    expect(page).to have_text(@proposal.proposal_type.name)
+    expect(page).to have_text(proposal.proposal_type.name)
   end
 
   scenario "there is a Year field containing the year" do
@@ -24,16 +24,17 @@ RSpec.feature "Proposal edit", type: :feature do
   end
 
   context "Subject Areas" do
-    before do
-      subject_category = create(:subject_category)
-      @subjects = create_list(:subject, 4, subject_category_id: subject_category.id)
-      @proposal.update(subject: @subjects.first)
+    let(:subjects) { create_list(:subject, 4, subject_category_id: subject_category.id) }
+    let(:subject_category) { create(:subject_category) }
 
-      visit edit_proposal_path(@proposal)
+    before do
+      proposal.update(subject: subjects.first)
+
+      visit edit_proposal_path(proposal)
     end
 
     scenario "there is a Subject Area field containing the subject area" do
-      expect(page).to have_select('subject_id', selected: @subjects.first.title)
+      expect(page).to have_select('subject_id', selected: subjects.first.title)
     end
   end
 
@@ -47,19 +48,18 @@ RSpec.feature "Proposal edit", type: :feature do
   end
 
   scenario "the Lead Organizer's information is shown" do
-    shows_person_info(@proposal.lead_organizer)
+    shows_person_info(proposal.lead_organizer)
   end
 
   scenario "the Suporting Organizers' information is shown" do
-    create(:invite, proposal: @proposal, status: 'confirmed',
-                    invited_as: 'Organizer')
+    create(:invite, proposal: proposal, status: 'confirmed', invited_as: 'Organizer')
+    proposal.reload
 
-    @proposal = Proposal.find(@proposal.id)
-    expect(@proposal.supporting_organizers).not_to be_empty
+    expect(proposal.supporting_organizers).not_to be_empty
 
-    visit edit_proposal_path(@proposal)
+    visit edit_proposal_path(proposal)
 
-    @proposal.supporting_organizers.each do |invite|
+    proposal.supporting_organizers.each do |invite|
       shows_person_info(invite.person)
     end
   end
@@ -69,11 +69,43 @@ RSpec.feature "Proposal edit", type: :feature do
 
     within("form#submit_proposal") do
       expect(have_field('#file-upload')).to be_truthy
-      upload_file = Rails.root.join('spec/fixtures/file.pdf').to_s
-      find_field('file-upload').attach_file(upload_file)
+    end
+  end
+
+  describe 'inviting members and organizers' do
+    before do
+      proposal.update_attribute(:title, title)
+      Invite.delete_all
+
+      visit edit_proposal_path(proposal)
     end
 
-    # Uploads must be tested via request tests
-    # expect(@proposal.files.attached?).to be_truthy
+    context 'when proposal title is not present' do
+      let(:title) { nil }
+
+      it 'has disabled invite organizers buttons' do
+        expect(page).to have_button('Invite Organizer(s)', disabled: true)
+        expect(page).to have_button('Queue More Organizer Invitations', disabled: true)
+      end
+
+      it 'has disabled add participants buttons' do
+        expect(page).to have_button('Invite Participant(s)', disabled: true)
+        expect(page).to have_button('Queue More Participant Invitations', disabled: true)
+      end
+    end
+
+    context 'when proposal title is present' do
+      let(:title) { 'New title' }
+
+      it 'has invite organizers buttons' do
+        expect(page).to have_button('Invite Organizer(s)', disabled: false)
+        expect(page).to have_button('Queue More Organizer Invitations', disabled: false)
+      end
+
+      it 'has add participants buttons' do
+        expect(page).to have_button('Invite Participant(s)', disabled: false)
+        expect(page).to have_button('Queue More Participant Invitations', disabled: false)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a form validation to `/proposals/:id/edit` so that inviting people is not possible until title is entered and draft is saved.

Make sure that https://github.com/birs-math/proposals/pull/964 is merged before merging this