### PR TITLE
Add Invite::Update service

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -22,17 +22,13 @@ class InvitesController < ApplicationController
   def update
     @proposal = Proposal.find(params[:proposal_id])
     @invite = @proposal.invites.find(params[:id])
-    if @invite.update(invite_params)
-      if @invite.update_invited_person(params["invite"]["affiliation"])
-        flash[:success] = t('invites.update.success')
-      else
-        flash[:alert] = t('invites.update.failure')
-      end
-    end
+
+    result = Invites::Update.new(invite: @invite, params: params[:invite]).call
+
     if lead_organizer?
-      redirect_to edit_proposal_path(@invite.proposal_id)
+      redirect_to edit_proposal_path(@invite.proposal_id), **result.flash_message
     else
-      redirect_to edit_submitted_proposal_url(@invite.proposal_id)
+      redirect_to edit_submitted_proposal_url(@invite.proposal_id), **result.flash_message
     end
   end
 

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -68,6 +68,7 @@ class Invite < ApplicationRecord
     person.firstname = firstname
     person.lastname = lastname
     person.email = email
+
     return true if person.save(validate: false)
   end
 

--- a/app/services/invites/update.rb
+++ b/app/services/invites/update.rb
@@ -14,7 +14,7 @@ module Invites
         if success?
           { notice: I18n.t('invites.update.success') }
         else
-          { alert: invite.errors.full_messages || I18n.t('invites.update.failure') }
+          { alert: invite.errors.full_messages.presence || [I18n.t('invites.update.failure')] }
         end
       end
     end

--- a/app/services/invites/update.rb
+++ b/app/services/invites/update.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Invites
+  class Update
+
+    MODEL_ATTRS = %i[firstname lastname email].freeze
+
+    Result = Struct.new(:invite, keyword_init: true) do
+      def success?
+        invite.valid?
+      end
+
+      def flash_message
+        if success?
+          { notice: I18n.t('invites.update.success') }
+        else
+          { alert: invite.errors.full_messages || I18n.t('invites.update.failure') }
+        end
+      end
+    end
+
+    def initialize(invite:, params:)
+      @invite = invite
+      @params = params
+
+      @invite.skip_deadline_validation = true if @invite.deadline_date < Date.current
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        invite.update(model_params)
+        invite.update_invited_person(params[:affiliation]) if params.key?(:affiliation)
+      end
+
+      Result.new(invite: invite)
+    end
+
+    private
+
+    attr_reader :invite, :params
+
+    def model_params
+      @model_params ||= if params.respond_to?(:permit)
+                          params.permit(*MODEL_ATTRS)
+                        else
+                          params.slice(*MODEL_ATTRS)
+                        end
+    end
+  end
+end

--- a/spec/services/invites/update_spec.rb
+++ b/spec/services/invites/update_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invites::Update do
+  subject(:result) { described_class.new(invite: invite, params: params).call }
+
+  let(:invite) { create(:invite) }
+  let(:params) do
+    ActiveSupport::HashWithIndifferentAccess.new(
+      { firstname: 'John', lastname: 'Doe', email: 'john.doe@example.com', affiliation: 'BIRS' }
+    )
+  end
+
+  def expect_to_update_attributes
+    expect(result.invite.firstname).to eq('John')
+    expect(result.invite.lastname).to eq('Doe')
+    expect(result.invite.email).to eq('john.doe@example.com')
+    expect(result.invite.person.affiliation).to eq('BIRS')
+  end
+
+  describe '#call' do
+    it { expect(result.success?).to be_truthy }
+
+    it('performs update') { expect_to_update_attributes }
+
+    context 'when bad params' do
+      let(:params) do
+        ActiveSupport::HashWithIndifferentAccess.new(
+          { firstname: 'John', lastname: 'Doe', email: '' }
+        )
+      end
+
+      it { expect(result.success?).to be_falsey }
+
+      it 'has error message' do
+        expect(result.flash_message[:alert]).to include('Email can\'t be blank')
+        expect(result.flash_message[:alert]).to include('Email is invalid')
+      end
+    end
+
+    context 'when past invite deadline date' do
+      before do
+        invite.assign_attributes(deadline_date: Date.yesterday)
+      end
+
+      it { expect(result.success?).to be_truthy }
+
+      it('still updates') { expect_to_update_attributes }
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes `edit invite` button not persisting records as well as moves invite update business logic into separate service