### PR TITLE
Show location code in /submitted_proposals

### DIFF
--- a/app/views/submitted_proposals/_proposals.html.erb
+++ b/app/views/submitted_proposals/_proposals.html.erb
@@ -26,9 +26,9 @@
       <td><%= proposal.title %></td>
       <td><%= proposal.proposal_type.name %></td>
       <td><%= proposal.lead_organizer&.fullname %></td>
-      <td> 
+      <td>
         <% proposal.locations.each do |loc| %>
-         <%= loc.name %><br>
+         <%= loc.code %><br>
         <% end %>
       </td>
       <td>


### PR DESCRIPTION
This PR adds a slight change to show location as a code instead of full name