### PR TITLE
More visibility on latex to pdf errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,12 +58,12 @@ jobs:
             gem install bundler
             bundle install
       - run:
-          name: Run migrations
+          name: Load schema
           command: |
             echo "127.0.0.1 db" >> /etc/hosts
             chown -R app:app /home/app/proposals
             cd /home/app/proposals
-            SECRET_KEY_BASE=token DB_USER=$DB_USER DB_PASS=$DB_PASS bin/rails db:migrate RAILS_ENV=test
+            SECRET_KEY_BASE=token DB_USER=$DB_USER DB_PASS=$DB_PASS bin/rails db:schema:load RAILS_ENV=test
       - run:
           name: Run the tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           command: |
             cd /home/app/proposals/db/pg-init
             sed s/DB_USER/$DB_USER/g db-init.sql | sed s/DB_PASS/$DB_PASS/g > setup.sql
-            PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres < setup.sql
+            PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -d proposals_test -U postgres < setup.sql
             rm setup.sql
       - run:
           name: Bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,8 @@ jobs:
           command: |
             cd /home/app/proposals/db/pg-init
             sed s/DB_USER/$DB_USER/g db-init.sql | sed s/DB_PASS/$DB_PASS/g > setup.sql
-            PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -d proposals_test -U postgres < setup.sql
+            PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -U postgres < setup.sql
+            PGPASSWORD=$POSTGRES_PASSWORD psql -h localhost -d proposals_test -U postgres -c "CREATE EXTENSION IF NOT EXISTS pgcrypto;"
             rm setup.sql
       - run:
           name: Bundle install

--- a/app/channels/proposal_booklet_channel.rb
+++ b/app/channels/proposal_booklet_channel.rb
@@ -1,6 +1,6 @@
 class ProposalBookletChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "proposal_booklet_channel_#{current_user.id}"
+    stream_for current_user
   end
 
   def unsubscribed

--- a/app/channels/proposal_booklet_channel.rb
+++ b/app/channels/proposal_booklet_channel.rb
@@ -1,6 +1,6 @@
 class ProposalBookletChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "proposal_booklet_channel"
+    stream_from "proposal_booklet_channel_#{current_user.id}"
   end
 
   def unsubscribed

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -144,8 +144,10 @@ class ProposalsController < ApplicationController
     flash[:alert] = "There are errors in your LaTeX code. Please see the
                         output from the compiler, and the LaTeX document,
                         below".squish
-    error_output = ProposalPdfService.format_errors(e)
-    render layout: "latex_errors", inline: error_output.to_s, formats: [:html]
+
+    log = CreatePdfToLatexLog.call(latex_temp_file, error: e.cause)
+
+    redirect_to booklet_log_submitted_proposals_path(log_id: log.id)
   end
 
   def set_careers

--- a/app/controllers/submitted_proposals_controller.rb
+++ b/app/controllers/submitted_proposals_controller.rb
@@ -211,7 +211,7 @@ class SubmittedProposalsController < ApplicationController
   end
 
   def download_file
-    log = LatexToPdfLog.find_by(log_id: params[:log_id])
+    log = LatexToPdfLog.find_by(id: params[:log_id])
 
     return head(:not_found) if log.blank?
 

--- a/app/controllers/submitted_proposals_controller.rb
+++ b/app/controllers/submitted_proposals_controller.rb
@@ -211,7 +211,7 @@ class SubmittedProposalsController < ApplicationController
   end
 
   def download_file
-    log = LatexToPdfLog.find_by(params[:log_id])
+    log = LatexToPdfLog.find_by(log_id: params[:log_id])
 
     return head(:not_found) if log.blank?
 

--- a/app/controllers/submitted_proposals_controller.rb
+++ b/app/controllers/submitted_proposals_controller.rb
@@ -210,7 +210,7 @@ class SubmittedProposalsController < ApplicationController
     @log = LatexToPdfLog.find(params[:log_id])
   end
 
-  def download_file
+  def download_log_file
     log = LatexToPdfLog.find_by(id: params[:log_id])
 
     return head(:not_found) if log.blank?

--- a/app/javascript/channels/proposal_booklet_channel.js
+++ b/app/javascript/channels/proposal_booklet_channel.js
@@ -12,12 +12,17 @@ consumer.subscriptions.create("ProposalBookletChannel", {
     $(".proposal-booklet-btn").html("Create Booklet")
     $(".proposal-booklet-btn").removeClass("disabled");
     $(".proposal-booklet-ok-btn").removeClass("disabled");
-    if ( typeof data["success"] === "undefined" ){
-      toastr.error(data["alert"])
-    }
-    else {
-      document.getElementById("proposal_booklet").click();
-      toastr.success(data["success"])
+    if (data['alert']){
+      if (data['log_id']) {
+        const new_path = new URL(window.location.origin + '/submitted_proposals/booklet_log')
+        new_path.searchParams.append('log_id', data['log_id'])
+        window.location.href = new_path.toString()
+      } else {
+        toastr.error(data['alert'])
+      }
+    } else if(data['success']) {
+      document.getElementById('proposal_booklet').click();
+      toastr.success(data['success'])
     }
   }
 });

--- a/app/jobs/proposal_booklet_job.rb
+++ b/app/jobs/proposal_booklet_job.rb
@@ -9,14 +9,14 @@ class ProposalBookletJob < ApplicationJob
 
     create_file
 
-    ActionCable.server.broadcast(
-      "proposal_booklet_channel_#{current_user.id}",
+    ProposalBookletChannel.broadcast_to(
+      current_user,
       { success: "Created proposals booklet. Now, it will download itself." }
     )
   rescue ActionView::Template::Error => e
     Rails.logger.info { "\n\nLaTeX error:\n #{e.message}\n\n" }
     log = create_log_record(e.cause)
-    ActionCable.server.broadcast("proposal_booklet_channel_#{current_user.id}", { alert: e.message, log_id: log.id })
+    ProposalBookletChannel.broadcast_to(current_user, { alert: e.message, log_id: log.id })
   end
 
   private

--- a/app/jobs/proposal_booklet_job.rb
+++ b/app/jobs/proposal_booklet_job.rb
@@ -2,33 +2,39 @@ class ProposalBookletJob < ApplicationJob
   queue_as :default
 
   def perform(proposal_ids, table, counter, current_user)
-    create_file(proposal_ids, table, counter, current_user)
+    @current_user = current_user
+    @proposal_ids = proposal_ids
+    @table = table
+    @counter = counter
+
+    create_file
 
     ActionCable.server.broadcast(
-      "proposal_booklet_channel", { success: "Created proposals booklet. Now, it will download itself." }
+      "proposal_booklet_channel_#{current_user.id}",
+      { success: "Created proposals booklet. Now, it will download itself." }
     )
-  rescue StandardError => e
+  rescue ActionView::Template::Error => e
     Rails.logger.info { "\n\nLaTeX error:\n #{e.message}\n\n" }
-    ActionCable.server.broadcast("proposal_booklet_channel", { alert: e.message })
-    raise e
+    log = create_log_record(e.cause)
+    ActionCable.server.broadcast("proposal_booklet_channel_#{current_user.id}", { alert: e.message, log_id: log.id })
   end
 
   private
 
-  def create_file(proposal_ids, table, counter, current_user)
-    temp_file = "propfile-#{current_user.id}-proposals-booklet.tex"
+  attr_reader :current_user, :proposal_ids, :table, :counter
+
+  def create_file
     if counter == 1
-      single_proposal_booklet(proposal_ids, temp_file, table, current_user)
+      single_proposal_booklet
     else
-      multiple_proposals_booklet(proposal_ids, temp_file, table, current_user)
+      multiple_proposals_booklet
     end
   end
 
-  def single_proposal_booklet(proposal_ids, temp_file, table, current_user)
+  def single_proposal_booklet
     proposal = Proposal.find_by(id: proposal_ids)
     BookletPdfService.new(proposal.id, temp_file, 'all', current_user).single_booklet(table)
-    fh = File.open("#{Rails.root}/tmp/#{temp_file}")
-    latex_infile = fh.read
+    latex_infile = read_temp_file
     latex_infile = LatexToPdf.escape_latex(latex_infile) if proposal.no_latex
     proposals_macros = proposal.macros
     write_file(proposals_macros, latex_infile)
@@ -36,33 +42,51 @@ class ProposalBookletJob < ApplicationJob
 
   def write_file(proposals_macros, latex_infile)
     latex = "#{proposals_macros}\n\\begin{document}\n#{latex_infile}"
-    ac = ActionController::Base.new
-    pdf_file = ac.render_to_string layout: "booklet", inline: latex, formats: [:pdf]
-    write_new_file(pdf_file)
-  end
+    pdf_contents = render_to_string layout: "booklet", inline: latex, formats: [:pdf]
+    pdf_path = Rails.root.join('tmp', pdf_file)
 
-  def write_new_file(pdf_file)
-    pdf_path = Rails.root.join('tmp/booklet-proposals.pdf')
     File.open(pdf_path, "w:UTF-8") do |file|
-      file.write(pdf_file)
+      file.write(pdf_contents)
     end
   end
 
-  def multiple_proposals_booklet(proposal_ids, temp_file, table, current_user)
-    create_booklet(proposal_ids, temp_file, table, current_user)
-    latex_infile = check_file_existence(proposal_ids, temp_file, table, current_user)
+  def render_to_string(...)
+    ActionController::Base.new.render_to_string(...)
+  end
+
+  def multiple_proposals_booklet
+    create_booklet
+    latex_infile = check_file_existence
     proposals_macros = ExtractPreamblesService.new(proposal_ids).proposal_preambles
     write_file(proposals_macros, latex_infile)
   end
 
-  def create_booklet(proposal_ids, temp_file, table, current_user)
+  def create_booklet
     BookletPdfService.new(proposal_ids.split(','), temp_file, 'all', current_user)
                      .multiple_booklet(table, proposal_ids)
   end
 
-  def check_file_existence(proposal_ids, temp_file, table, current_user)
-    create_booklet(proposal_ids, temp_file, table, current_user) unless File.exist?("#{Rails.root}/tmp/#{temp_file}")
-    fh = File.open("#{Rails.root}/tmp/#{temp_file}")
-    fh.read
+  def check_file_existence
+    create_booklet unless File.exist?("#{Rails.root}/tmp/#{temp_file}")
+    read_temp_file
+  end
+
+  def temp_file
+    return @temp_file if defined?(@temp_file)
+
+    identifier = proposal_ids.respond_to?(:each) ? proposal_ids.join('-') : proposal_ids
+    @temp_file = "propfile-#{current_user.id}-#{identifier}-proposals-booklet.tex"
+  end
+
+  def pdf_file
+    @pdf_file ||= "booklet-proposals-#{current_user.id}.pdf"
+  end
+
+  def read_temp_file
+    File.read("#{Rails.root}/tmp/#{temp_file}")
+  end
+
+  def create_log_record(error)
+    LatexToPdfLog.create(log: error.log.lines.last(20).join("\n"), file_name: temp_file)
   end
 end

--- a/app/jobs/proposal_booklet_job.rb
+++ b/app/jobs/proposal_booklet_job.rb
@@ -15,7 +15,8 @@ class ProposalBookletJob < ApplicationJob
     )
   rescue ActionView::Template::Error => e
     Rails.logger.info { "\n\nLaTeX error:\n #{e.message}\n\n" }
-    log = create_log_record(e.cause)
+
+    log = CreatePdfToLatexLog.call(temp_file, error: e.cause)
     ProposalBookletChannel.broadcast_to(current_user, { alert: e.message, log_id: log.id })
   end
 
@@ -84,9 +85,5 @@ class ProposalBookletJob < ApplicationJob
 
   def read_temp_file
     File.read("#{Rails.root}/tmp/#{temp_file}")
-  end
-
-  def create_log_record(error)
-    LatexToPdfLog.create(log: error.log.lines.last(20).join("\n"), file_name: temp_file)
   end
 end

--- a/app/models/latex_to_pdf_log.rb
+++ b/app/models/latex_to_pdf_log.rb
@@ -1,0 +1,10 @@
+# Right now only used for storing source latex file when ProposalBookletJob encounters rendering error
+class LatexToPdfLog < ApplicationRecord
+  before_create :identify_mime_type
+
+  private
+
+  def identify_mime_type
+    self.mime_type = MiniMime.lookup_by_filename(file_name).content_type if mime_type.blank?
+  end
+end

--- a/app/services/booklet_pdf_service.rb
+++ b/app/services/booklet_pdf_service.rb
@@ -142,7 +142,7 @@ class BookletPdfService
   end
 
   def selected_proposals_subjects(proposals)
-    subjects_with_proposals = proposals.sort_by { |p| p&.subject&.title }.group_by(&:subject_id)
+    subjects_with_proposals = proposals.sort_by { |p| p&.subject&.title || '' }.group_by(&:subject_id)
     first_subject_proposal(subjects_with_proposals)
     subjects_with_proposals
   end

--- a/app/services/booklet_pdf_service.rb
+++ b/app/services/booklet_pdf_service.rb
@@ -25,20 +25,6 @@ class BookletPdfService
     multiple_proposals_fields(year) if @input == 'all'
   end
 
-  def self.format_errors(error)
-    @error_object = error.cause # RailsLatex::ProcessingError
-    @error_summary = @error_object.log.lines.last(20).join("\n")
-
-    save_error_messages
-
-    line_num = 1
-    @error_object.src.each_line do |line|
-      @error_output << (line_num.to_s + " #{line}")
-      line_num += 1
-    end
-    @error_output << "\n</pre>\n\n"
-  end
-
   private
 
   def save_error_messages

--- a/app/services/create_pdf_to_latex_log.rb
+++ b/app/services/create_pdf_to_latex_log.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreatePdfToLatexLog
+  include Callable
+
+  def initialize(latex_source, error: nil)
+    @error = error
+    @latex_source = latex_source
+  end
+
+  def call
+    LatexToPdfLog.create(log: capture_log, file_name: latex_source)
+  end
+
+  private
+
+  def capture_log
+    return '' unless error.respond_to?(:log)
+
+    error.log.lines.last(20).join("\n")
+  end
+
+  attr_reader :error, :latex_source
+end

--- a/app/services/proposal_pdf_service.rb
+++ b/app/services/proposal_pdf_service.rb
@@ -48,33 +48,6 @@ class ProposalPdfService
     "#{@proposal.macros}\n\n\\begin{document}\n\n#{latex_infile}\n"
   end
 
-  def self.format_errors(error)
-    error_object = error.cause # RailsLatex::ProcessingError
-    error_summary = error_object.log.lines.last(20).join("\n")
-
-    error_output = "<h2 class=\"text-danger\">LaTeX Error Log:</h2>\n\n"
-    error_output << "<h4>Last 20 lines:</h4>\n\n"
-    error_output << "<pre>\n#{error_summary}\n</pre>\n\n"
-    error_output << %q(
-      <button class="btn btn-primary mb-4 latex-show-more" type="button"
-                     data-bs-toggle="collapse" data-bs-target="#latex-error"
-                     aria-expanded="false" aria-controls="latex-error">
-              Show full error log
-      </button>')
-    error_output << "<pre class=\"collapse\" id=\"latex-error\">\n"
-    error_output << "#{error_object.log}\n</pre>\n\n"
-
-    error_output << "<h2 class=\"text-danger p-4\">LaTeX Source File:</h2>\n\n"
-    error_output << "<pre id=\"latex-source\">\n"
-
-    line_num = 1
-    error_object.src.each_line do |line|
-      error_output << (line_num.to_s + " #{line}")
-      line_num += 1
-    end
-    error_output << "\n</pre>\n\n"
-  end
-
   private
 
   def all_proposal_fields

--- a/app/views/submitted_proposals/booklet_log.html.erb
+++ b/app/views/submitted_proposals/booklet_log.html.erb
@@ -1,0 +1,18 @@
+<main class="content">
+  <div class="container-fluid">
+    <div class="header">
+      <h1 class="header-title">LaTex log</h1>
+    </div>
+    <div class="card">
+      <div class="card-body">
+        <div class="row">
+          <%= simple_format(@log.log) %>
+        </div>
+        <div class="row">
+        <%= link_to "Source file", download_file_submitted_proposals_path(@log) %>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+

--- a/app/views/submitted_proposals/booklet_log.html.erb
+++ b/app/views/submitted_proposals/booklet_log.html.erb
@@ -9,7 +9,7 @@
           <%= simple_format(@log.log) %>
         </div>
         <div class="row">
-        <%= link_to "Source file", download_file_submitted_proposals_path(log_id: @log) %>
+        <%= link_to "Source file", download_log_file_submitted_proposals_path(log_id: @log) %>
         </div>
       </div>
     </div>

--- a/app/views/submitted_proposals/booklet_log.html.erb
+++ b/app/views/submitted_proposals/booklet_log.html.erb
@@ -9,7 +9,7 @@
           <%= simple_format(@log.log) %>
         </div>
         <div class="row">
-        <%= link_to "Source file", download_file_submitted_proposals_path(@log) %>
+        <%= link_to "Source file", download_file_submitted_proposals_path(log_id: @log) %>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,11 +16,14 @@ Rails.application.routes.draw do
   get 'dashboards', to: 'proposal_types#index'
 
   resources :submitted_proposals do
+    get :booklet_log, on: :collection
+
     collection do
       get :download_csv
       post :send_to_workshop
       post :proposals_booklet
       get :download_booklet
+      get :download_file
       post :edit_flow
       post :revise_proposal_editflow
       post :approve_decline_proposals

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
       post :send_to_workshop
       post :proposals_booklet
       get :download_booklet
-      get :download_file
+      get :download_log_file
       post :edit_flow
       post :revise_proposal_editflow
       post :approve_decline_proposals

--- a/db/migrate/0_enable_pg_extensions.rb
+++ b/db/migrate/0_enable_pg_extensions.rb
@@ -1,5 +1,0 @@
-class EnablePgExtensions < ActiveRecord::Migration[6.1]
-  def change
-    enable_extension 'pgcrypto'
-  end
-end

--- a/db/migrate/0_enable_pg_extensions.rb
+++ b/db/migrate/0_enable_pg_extensions.rb
@@ -1,6 +1,5 @@
 class EnablePgExtensions < ActiveRecord::Migration[6.1]
   def change
-    enable_extension 'uuid-ossp'
     enable_extension 'pgcrypto'
   end
 end

--- a/db/migrate/0_enable_pg_extensions.rb
+++ b/db/migrate/0_enable_pg_extensions.rb
@@ -1,0 +1,6 @@
+class EnablePgExtensions < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension 'uuid-ossp'
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20230523063029_create_latex_to_pdf_logs.rb
+++ b/db/migrate/20230523063029_create_latex_to_pdf_logs.rb
@@ -1,0 +1,10 @@
+class CreateLatexToPdfLogs < ActiveRecord::Migration[6.1]
+  def change
+    create_table :latex_to_pdf_logs, id: :uuid do |t|
+      t.text :log
+      t.string :file_name
+      t.string :mime_type
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,9 @@
 ActiveRecord::Schema.define(version: 2023_05_30_113342) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -149,6 +149,14 @@ ActiveRecord::Schema.define(version: 2023_05_30_113342) do
     t.index ["proposal_id"], name: "index_invites_on_proposal_id"
   end
 
+  create_table "latex_to_pdf_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "log"
+    t.string "file_name"
+    t.string "mime_type"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "locations", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 2023_05_30_113342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
-  enable_extension "uuid-ossp"
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,6 @@
 ActiveRecord::Schema.define(version: 2023_05_30_113342) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "action_text_rich_texts", force: :cascade do |t|

--- a/spec/channels/proposal_booklet_channel_spec.rb
+++ b/spec/channels/proposal_booklet_channel_spec.rb
@@ -1,10 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe ProposalBookletChannel, type: :channel do
+  let(:current_user) { create(:user) }
+
   it "subscribes to a stream" do
+    stub_connection(current_user: current_user)
+
     subscribe
 
     expect(subscription).to be_confirmed
-    expect(subscription).to have_stream_from("proposal_booklet_channel")
+    expect(subscription).to have_stream_for(current_user)
   end
 end


### PR DESCRIPTION
This PR is an initial attempt to provide more context on errors that occur when proposals are rendered from LaTex to PDF.

Changes:
* Makes pdf downloads uniq by current user, it will now not collide with other ongoing booklet downloads.
* Makes render errors generate `PdfToLatexLog` record that stores path to file and error log for debugging.
* Makes app render page with error and appropriate links when PDF to LaTex error occurs.
* Refactors `ProposalBookletJob` to use instance variables instead of argument drilling.