### PR TITLE
Fix duplicates of demographic data

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -12,7 +12,7 @@ class PeopleController < ApplicationController
 
   def update
     if @person.update(person_params)
-      if @person.demographic_survey_submitted?
+      if @person.demographic_data.present?
         redirect_to root_path
       else
         redirect_to new_survey_path(code: params[:code], response: params[:response]),

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -12,8 +12,12 @@ class PeopleController < ApplicationController
 
   def update
     if @person.update(person_params)
-      redirect_to new_survey_path(code: params[:code], response: params[:response]),
-                  notice: t('people.update.success')
+      if @person.demographic_survey_submitted?
+        redirect_to root_path
+      else
+        redirect_to new_survey_path(code: params[:code], response: params[:response]),
+                    notice: t('people.update.success')
+      end
     else
       @invited_as = invite&.invited_as
       render :new

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -61,10 +61,6 @@ class Person < ApplicationRecord
     proposals.where(status: :draft).present?
   end
 
-  def demographic_survey_submitted?
-    !DemographicData.exists?({ person_id: 24, result: "{}" })
-  end
-
   private
 
   def strip_whitespace

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -61,6 +61,10 @@ class Person < ApplicationRecord
     proposals.where(status: :draft).present?
   end
 
+  def demographic_survey_submitted?
+    !DemographicData.exists?({ person_id: 24, result: "{}" })
+  end
+
   private
 
   def strip_whitespace


### PR DESCRIPTION
This PR makes sure that people that have already filled demographic survey will not be prompted to fill it again.

In another PR (https://github.com/birs-math/proposals/pull/985) It was made so that only last filled in survey is taken into account when calculating statistics based on surveys