### PR TITLE
Email section enhacements

### DIFF
--- a/app/controllers/submitted_proposals_controller.rb
+++ b/app/controllers/submitted_proposals_controller.rb
@@ -84,6 +84,7 @@ class SubmittedProposalsController < ApplicationController
     add_files
     if @email.save
       @email.send_email
+      log_activity(@proposal)
       page_redirect
     else
       @message = @email.errors.full_messages

--- a/app/controllers/submitted_proposals_controller.rb
+++ b/app/controllers/submitted_proposals_controller.rb
@@ -82,9 +82,8 @@ class SubmittedProposalsController < ApplicationController
       return
     end
     add_files
-    organizers_email_addresses
     if @email.save
-      @email.email_organizers(@organizers_email)
+      @email.send_email
       page_redirect
     else
       @message = @email.errors.full_messages
@@ -241,7 +240,7 @@ class SubmittedProposalsController < ApplicationController
   end
 
   def email_params
-    params.permit(:subject, :body, :cc_email, :bcc_email)
+    params.permit(:subject, :body, :recipient, :cc_email, :bcc_email)
   end
 
   def set_proposals
@@ -489,7 +488,7 @@ class SubmittedProposalsController < ApplicationController
   def send_email_proposals
     add_attachments
     organizers_email = @proposal.invites.where(invited_as: 'Organizer', status: :confirmed)&.pluck(:email)
-    @email.new_email_organizers(organizers_email) if @email.save
+    @email.email_organizers(organizers_email) if @email.save
     @errors << @email.errors.full_messages unless @email.errors.empty?
   end
 

--- a/app/helpers/submitted_proposals_helper.rb
+++ b/app/helpers/submitted_proposals_helper.rb
@@ -88,7 +88,7 @@ module SubmittedProposalsHelper
   end
 
   def organizers_email(proposal)
-    proposal.invites.where(invited_as: 'Organizer').map(&:person).map(&:email)
+    proposal.supporting_organizer_invites.pluck(:email)
   end
 
   def review_dates(review)

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -12,20 +12,23 @@ class ProposalMailer < ApplicationMailer
 
   def staff_send_emails
     @email = params[:email_data]
+    @recipient_name = @email.recipient_fullname_or_email
 
     preview_placeholders if @email.proposal.decision_email_sent?
 
-    @organizer = params[:organizer]
     mail_attachments
-    send_mails
+
+    mail(**@email.to_action_mailer_hash)
   end
 
+  # TODO: we don't need two similar methods
   def new_staff_send_emails
     @email = params[:email_data]
     preview_placeholders if @email.proposal.decision_email_sent?
     @organizer = params[:organizer]
     mail_attachments
-    new_send_mails
+
+    mail(**@email.to_action_mailer_hash.merge(to: params[:email]))
   end
 
   private
@@ -36,34 +39,6 @@ class ProposalMailer < ApplicationMailer
            cc: @proposal.birs_emails)
     else
       mail(to: email, subject: "BIRS Proposal #{@proposal.code}: #{@proposal.title}")
-    end
-  end
-
-  def new_send_mails
-    email_address = params[:email]
-    if @email.cc_email.present? && @email.bcc_email.present?
-      mail(to: email_address, subject: @email.subject, cc: @email.all_emails(@email.cc_email),
-           bcc: @email.all_emails(@email.bcc_email))
-    elsif @email.cc_email.present?
-      mail(to: email_address, subject: @email.subject, cc: @email.all_emails(@email.cc_email))
-    elsif @email.bcc_email.present?
-      mail(to: email_address, subject: @email.subject, bcc: @email.all_emails(@email.bcc_email))
-    else
-      mail(to: email_address, subject: @email.subject)
-    end
-  end
-
-  def send_mails
-    email_address = params[:email]
-    if @email.cc_email.present? && @email.bcc_email.present?
-      mail(to: email_address, subject: @email.subject, cc: @email.all_cc_emails(@email.cc_email),
-           bcc: @email.all_emails(@email.bcc_email))
-    elsif @email.cc_email.present?
-      mail(to: email_address, subject: @email.subject, cc: @email.all_cc_emails(@email.cc_email))
-    elsif @email.bcc_email.present?
-      mail(to: email_address, subject: @email.subject, bcc: @email.all_emails(@email.bcc_email))
-    else
-      mail(to: email_address, subject: @email.subject)
     end
   end
 

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -86,8 +86,7 @@ class ProposalMailer < ApplicationMailer
                                                                      .map do |p|
                                                                  "#{p.firstname} #{p.lastname}"
                                                                end.join(', '),
-                     "[WORKSHOP SUPPORTING_ORGANIZER_EMAIL]" => "#{JSON.parse(@email.cc_email).map(&:values).flatten
-                     .join(', ')}, #{@email.bcc_email}",
+                     "[WORKSHOP SUPPORTING_ORGANIZER_EMAIL]" => @email.cc_email,
                      "[INSERT ASSIGNED DATES]" => workshop_date_range(@email.proposal&.assigned_date),
                      "[INSERT APPLIED DATES]" => workshop_date_range(@email.proposal&.applied_date) }
     placeholders.each { |k, v| @template_body.gsub!(k, v) }

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -69,6 +69,10 @@ class Email < ApplicationRecord
     Person.find_by(email: to_email)&.fullname || to_email
   end
 
+  def string_to_a(emails_string)
+    emails_string&.split(',')&.map(&:squish) || []
+  end
+
   private
 
   def unwrap_cc_emails
@@ -111,9 +115,5 @@ class Email < ApplicationRecord
     JSON.parse(emails_string).map(&:values).flatten
   rescue JSON::ParserError, TypeError
     string_to_a(emails_string)
-  end
-
-  def string_to_a(emails_string)
-    emails_string.split(',').map(&:squish)
   end
 end

--- a/app/views/emails/_form.html.erb
+++ b/app/views/emails/_form.html.erb
@@ -8,7 +8,8 @@
       <div class="mb-3">
         <h4>Email Addresses of Organizers</h4>
         <div class="mb-3">
-          <p><%= @proposal.lead_organizer.email %></p>
+          <%= f.label :recipient, class: 'form-label' %>
+          <%= f.text_field :recipient, class: 'form-control', value: @proposal.lead_organizer.email %>
           <label>CC</label>
           <input name="cc_email" id="cc_email" data-submitted-proposals-target="organizersEmail" value="<%= organizers_email(@proposal) %>">
           <small>This text field supports a list of Cc emails. For example: birs@example.com, noreply@example.com, …</small>

--- a/app/views/proposal_mailer/staff_send_emails.html.erb
+++ b/app/views/proposal_mailer/staff_send_emails.html.erb
@@ -1,2 +1,2 @@
-<p>Dear <%= @organizer %>,</p>
-<p><%= raw @email.body %></p>
+<p>Dear <%= @recipient_name %>,</p>
+<%= simple_format(@email.body) %>

--- a/app/views/proposal_mailer/staff_send_emails.text.erb
+++ b/app/views/proposal_mailer/staff_send_emails.text.erb
@@ -1,3 +1,2 @@
-Dear <%= @organizer %>,
-
-<%= @email.body %>
+Dear <%= @recipient_name %>,
+<%= raw(@email.body) %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -9,8 +9,8 @@ local:
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+#   access_key_id: <%#= Rails.application.credentials.dig(:aws, :access_key_id) %>
+#   secret_access_key: <%#= Rails.application.credentials.dig(:aws, :secret_access_key) %>
 #   region: us-east-1
 #   bucket: your_own_bucket
 
@@ -18,14 +18,14 @@ local:
 # google:
 #   service: GCS
 #   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
+#   credentials: <%#= Rails.root.join("path/to/gcs.keyfile") %>
 #   bucket: your_own_bucket
 
 # Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
 # microsoft:
 #   service: AzureStorage
 #   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+#   storage_access_key: <%#= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
 #   container: your_container_name
 
 # mirror:

--- a/db/migrate/20230718074420_add_recipient_to_emails.rb
+++ b/db/migrate/20230718074420_add_recipient_to_emails.rb
@@ -1,0 +1,6 @@
+class AddRecipientToEmails < ActiveRecord::Migration[6.1]
+
+  def change
+    add_column :emails, :recipient, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_21_123316) do
+ActiveRecord::Schema.define(version: 2023_07_18_074420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2023_06_21_123316) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "cc_email"
     t.string "bcc_email"
+    t.string "recipient"
     t.index ["proposal_id"], name: "index_emails_on_proposal_id"
   end
 

--- a/lib/scripts/convert_cc_email_to_string_from_json.rb
+++ b/lib/scripts/convert_cc_email_to_string_from_json.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Email.find_each do |email|
+  email.send(:unwrap_cc_emails)
+  email.save if email.changed?
+end

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -127,16 +127,7 @@ RSpec.describe Email, type: :model do
       end
     end
 
-    
-    it { expect(birs_email.update_status(proposal, 'Draft')).to be_falsey }
-  end
 
-  describe '#all_emails' do
-    let(:proposal) { create(:proposal) }
-    let(:birs_email) { create(:birs_email, proposal: proposal) }
-    let(:email) { ['test1@test.com', 'test2@test.com', 'test3@test.com'] }
-    it 'fetching all emails' do
-      expect(birs_email.all_emails(email)).to eq([email])
-    end
+    it { expect(birs_email.update_status(proposal, 'Draft')).to be_falsey }
   end
 end

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -127,10 +127,8 @@ RSpec.describe Email, type: :model do
       end
     end
 
-
     it { expect(birs_email.update_status(proposal, 'Draft')).to be_falsey }
   end
-
 
   describe '#unwrap_cc_emails' do
     let(:email) { build(:birs_email) }

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -130,4 +130,31 @@ RSpec.describe Email, type: :model do
 
     it { expect(birs_email.update_status(proposal, 'Draft')).to be_falsey }
   end
+
+
+  describe '#unwrap_cc_emails' do
+    let(:email) { build(:birs_email) }
+    let(:wrapped_cc_email) { [{ value: 'somemail@example.com' }, { value: 'othermail@example.com' }].to_json }
+    let(:unwrapped_cc_email) { 'somemail@example.com, othermail@example.com' }
+
+    it 'parses JSON' do
+      email.cc_email = wrapped_cc_email
+      expect(email.send(:unwrap_cc_emails)).to eq(unwrapped_cc_email)
+    end
+
+    it 'does not touch strings' do
+      email.cc_email = unwrapped_cc_email
+      expect(email.send(:unwrap_cc_emails)).to eq(unwrapped_cc_email)
+    end
+
+    it 'does not error on empty strings' do
+      email.cc_email = ''
+      expect(email.send(:unwrap_cc_emails)).to eq('')
+    end
+
+    it 'does not error on nil' do
+      email.cc_email = nil
+      expect(email.send(:unwrap_cc_emails)).to eq('')
+    end
+  end
 end

--- a/spec/requests/submitted_proposals_spec.rb
+++ b/spec/requests/submitted_proposals_spec.rb
@@ -299,6 +299,7 @@ RSpec.describe "/submitted_proposals", type: :request do
         expect(response).to have_http_status(:ok)
       end
     end
+
     context 'when proposal can not be approved/rejected' do
       before do
         proposal.update(status: :submitted)


### PR DESCRIPTION
This PR provides changes to emails section in `/submitted_proposals/:id`

Changes:
* Now `cc_email` is unwrapped from JSON to just string, since `_email_template.html.erb` just sends string version of `cc_email`, while emails section in `/submitted_proposals/:id` sends a JSON
* Added script to unwrap old email records that have stored cc_email as JSON