### PR TITLE
Fix some invite emails not being sent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'sass-rails', '>= 6'
 gem 'tinymce-rails', '5.10.2'
 gem 'turbo-rails', '~> 1.4'
 gem 'webpacker', '~> 5.0'
+gem 'sucker_punch', '~> 3.0'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,6 +367,8 @@ GEM
       net-ssh (>= 2.8.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    sucker_punch (3.1.0)
+      concurrent-ruby (~> 1.0)
     thor (1.2.2)
     tilt (2.2.0)
     timeout (0.3.2)
@@ -463,6 +465,7 @@ DEPENDENCIES
   simplecov
   simplecov-lcov
   spring
+  sucker_punch (~> 3.0)
   tinymce-rails (= 5.10.2)
   turbo-rails (~> 1.4)
   web-console (>= 4.1.0)

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,6 +1,6 @@
 class InvitesController < ApplicationController
   before_action :authenticate_user!, except: %i[show inviter_response thanks cancelled]
-  before_action :set_proposal, only: %i[invite_reminder invite_email new_invite]
+  before_action :set_proposal, only: %i[invite_reminder new_invite]
   before_action :set_invite,
                 only: %i[show inviter_response invite_reminder]
   before_action :set_invite_proposal, only: %i[show]
@@ -30,21 +30,6 @@ class InvitesController < ApplicationController
     else
       redirect_to edit_submitted_proposal_url(@invite.proposal_id), **result.flash_message
     end
-  end
-
-  def invite_email
-    inviters = if params[:id].eql?("0")
-                 Invite.where(proposal_id: @proposal.id, invited_as: params[:invited_as])
-                else
-                  Invite.where(proposal_id: @proposal.id, invited_as: params[:invited_as]).where('id > ?', params[:id])
-                end
-
-    inviters.each do |invite|
-      InviteMailer.with(invite: invite, lead_organizer_copy: false).invite_email.deliver_later
-      InviteMailer.with(invite: invite, lead_organizer_copy: true).invite_email.deliver_later
-    end
-
-    head :ok
   end
 
   def inviter_response

--- a/app/controllers/submit_proposals_controller.rb
+++ b/app/controllers/submit_proposals_controller.rb
@@ -52,9 +52,11 @@ class SubmitProposalsController < ApplicationController
     params[:invites_attributes].each_value do |invite|
       @invite = @proposal.invites.new(invite_params(invite))
       invite_save
-      next if @invite.errors.empty?
-
-      invalid_email_error_message
+      if @invite.errors.empty?
+        @invite.send_invite_email
+      else
+        invalid_email_error_message
+      end
     end
 
     render json: { errors: @errors, counter: @counter }, status: :ok

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -7,10 +7,6 @@ module ProposalsHelper
     proposal_type.map { |pt| [pt.name, pt.id] }
   end
 
-  def no_of_participants(id, invited_as)
-    Invite.where('invited_as = ? AND proposal_id = ?', invited_as, id)
-  end
-
   def confirmed_participants(id, invited_as)
     Invite.where('invited_as = ? AND proposal_id = ?', invited_as, id)
           .where.not(status: 'cancelled')

--- a/app/javascript/controllers/nested_invites_controller.js
+++ b/app/javascript/controllers/nested_invites_controller.js
@@ -147,8 +147,6 @@ export default class extends Controller {
 
   sendInviteEmails(id, invitedAs, inviteId, data) {
     var url = ''
-    let formData = new FormData()
-    let emailBody = $('#email_body').text()
     if(data.errors.length > 0 && data.counter === 0) {
        $.each(data.errors, function(index, error) {
         toastr.error(error)
@@ -161,12 +159,10 @@ export default class extends Controller {
       $.each(data.errors, function(index, error) {
         toastr.error(error)
       })
-      formData.append("body", emailBody)
       url = `/proposals/${id}/invites/${inviteId}/invite_email?invited_as=${invitedAs}`
       Rails.ajax({
         url,
         type: "POST",
-        data: formData,
         success: () => {
           setTimeout(function() {
             window.location.reload();
@@ -175,12 +171,10 @@ export default class extends Controller {
       })
     }
     else {
-      formData.append("body", emailBody)
       url = `/proposals/${id}/invites/${inviteId}/invite_email?invited_as=${invitedAs}`
       Rails.ajax({
         url,
         type: "POST",
-        data: formData,
         success: () => {
           toastr.success('Invitation has been sent!')
           setTimeout(function() {

--- a/app/lib/invite_mailer_context.rb
+++ b/app/lib/invite_mailer_context.rb
@@ -27,13 +27,14 @@ class InviteMailerContext
     @invite = params[:invite]
     @proposal = invite.proposal
     @params = params
+    @person = invite.person
   end
 
   def call
     {
-      person_name: invite.person&.fullname,
-      person_firstname: invite.person&.firstname,
-      person_lastname: invite.person&.lastname,
+      person_name: invitee_fullname,
+      person_firstname: invitee_firstname,
+      person_lastname: invitee_lastname,
       invited_as: invited_as_text(invite),
       invited_role: invite.humanize_invited_as,
       proposal_type: proposal.proposal_type.name,
@@ -48,10 +49,22 @@ class InviteMailerContext
 
   private
 
-  attr_reader :invite, :proposal, :params
+  attr_reader :invite, :person, :proposal, :params
+
+  def invitee_firstname
+    person&.firstname || invite.firstname
+  end
+
+  def invitee_lastname
+    person&.lastname || invite.lastname
+  end
+
+  def invitee_fullname
+    "#{invitee_firstname} #{invitee_lastname}"
+  end
 
   def supporting_organizers
-    @supporting_organizers ||= invite.proposal.supporting_organizers.map(&:fullname)
+    @supporting_organizers ||= proposal.supporting_organizers.map(&:fullname)
   end
 
   def invited_as_text(invite)

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -82,6 +82,11 @@ class Invite < ApplicationRecord
     deadline_date >= DateTime.current.beginning_of_day
   end
 
+  def send_invite_email
+    InviteMailer.with(invite: self, lead_organizer_copy: false).invite_email.deliver_later
+    InviteMailer.with(invite: self, lead_organizer_copy: true).invite_email.deliver_later
+  end
+
   private
 
   def downcase_email

--- a/app/views/proposals/_email_preview.html.erb
+++ b/app/views/proposals/_email_preview.html.erb
@@ -12,8 +12,7 @@
         <p id="email_body" class="d-none"></p>
       </div>
       <div class="modal-footer" data-controller="nested-invites">
-        <button data-action="click->nested-invites#sendInvite" data-id="<%= @proposal.id %>" class="btn btn-secondary" data-organizer="<%= no_of_participants(@proposal.id, 'Organizer').last&.id %>"
-        data-participant="<%= no_of_participants(@proposal.id, 'Participant').last&.id %>">Send Invitation</button>
+        <button data-action="click->nested-invites#sendInvite" data-id="<%= @proposal.id %>" class="btn btn-secondary">Send Invitation</button>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
       </div>
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,6 +14,8 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  config.active_job.queue_adapter = :sucker_punch
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  config.active_job.queue_adapter = :sucker_punch
   # config.active_job.queue_name_prefix = "proposals_production"
 
   config.action_mailer.perform_caching = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -7,6 +7,8 @@ Rails.application.configure do
 
   config.consider_all_requests_local = true
 
+  config.active_job.queue_adapter = :sucker_punch
+
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,7 +86,6 @@ Rails.application.routes.draw do
       member do
         post :inviter_response
         post :invite_reminder
-        post :invite_email
         post :new_invite
       end
       collection do

--- a/spec/helpers/proposals_helper_spec.rb
+++ b/spec/helpers/proposals_helper_spec.rb
@@ -164,14 +164,6 @@ RSpec.describe ProposalsHelper, type: :helper do
     end
   end
 
-  describe "#no_of_participants" do
-    let(:proposal) { create(:proposal) }
-    let(:invites) { create_list(:invite, 2, proposal_id: proposal.id, invited_as: "Organizer") }
-    it "returns total  participants" do
-      expect(no_of_participants(proposal.id, "Organizer")).to eq(invites)
-    end
-  end
-
   describe "#confirmed_participants" do
     let(:proposal) { create(:proposal) }
     let(:invites) { create_list(:invite, 2, proposal_id: proposal.id, invited_as: "Organizer", status: "confirmed") }

--- a/spec/requests/invites_spec.rb
+++ b/spec/requests/invites_spec.rb
@@ -288,42 +288,6 @@ RSpec.describe "/proposals/:proposal_id/invites", type: :request do
     end
   end
 
-  describe "POST /invite_email" do
-    context 'when id in params is 0' do
-      before do
-        authenticate_for_controllers
-        params = {
-          proposal_id: proposal.id,
-          id: 0,
-          code: invite.code,
-          invited_as: "Participant",
-          body: "Send email to participant for proposal invitation."
-        }
-        post invite_email_proposal_invite_path(params)
-      end
-      it "send invite email" do
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context 'when id in params is not 0' do
-      before do
-        authenticate_for_controllers
-        params = {
-          proposal_id: proposal.id,
-          id: invite.id,
-          code: invite.code,
-          invited_as: "Participant",
-          body: "Send email to participant for proposal invitation."
-        }
-        post invite_email_proposal_invite_path(params)
-      end
-      it "send invite email" do
-        expect(response).to have_http_status(:ok)
-      end
-    end
-  end
-
   describe "POST /inviter_reminder with staff member" do
     before do
       authenticate_for_controllers


### PR DESCRIPTION
After looking more into the email bug with invites it might be a problem with js code and a two-step process to send invites. It tries to first create invites with the first request, then send emails with the second. I’ve made it so that invites are created and sent with one request. 

I have also added SuckerPunch as an ActiveJob adapter, it does not require a standalone worker and does not persist queues, but it is ok to run mailing jobs.