### PR TITLE
Fix proposal locations order

### DIFF
--- a/app/controllers/submitted_proposals_controller.rb
+++ b/app/controllers/submitted_proposals_controller.rb
@@ -20,7 +20,8 @@ class SubmittedProposalsController < ApplicationController
       # loads proposals by type using turbo lazy loading
       format.turbo_stream do
         @type = params[:proposal_type]
-        @pagy, @proposals = pagy(proposals_query_with_filters.includes(:assigned_location, :locations), items: 100)
+        @pagy, @proposals =
+          pagy(proposals_query_with_filters.includes(:assigned_location, :locations, :lead_organizer), items: 100)
       end
     end
   end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -12,6 +12,8 @@ class Proposal < ApplicationRecord
   belongs_to :proposal_type
   has_many :proposal_roles, dependent: :destroy
   has_many :people, through: :proposal_roles
+  has_one :lead_organizer_proposal_role, -> { lead_organizer }, class_name: 'ProposalRole'
+  has_one :lead_organizer, through: :lead_organizer_proposal_role, source: :person
   has_many(:answers, -> { order 'answers.proposal_field_id' },
            inverse_of: :proposal, dependent: :destroy)
   has_many :invites, dependent: :destroy
@@ -157,10 +159,6 @@ class Proposal < ApplicationRecord
 
   def create_organizer_role(person, organizer)
     proposal_roles.create!(person: person, role: organizer)
-  end
-
-  def lead_organizer
-    Person.joins(proposal_roles: :role).find_by(proposal_roles: { proposal_id: id }, roles: { name: Role::LEAD_ORGANIZER })
   end
 
   def location_names

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -7,7 +7,7 @@ class Proposal < ApplicationRecord
 
   has_many_attached :files
   has_many :proposal_locations, dependent: :destroy
-  has_many :locations, -> { joins(:proposal_locations).order('proposal_locations.position') },
+  has_many :locations, -> { includes(:proposal_locations).order('proposal_locations.position') },
            through: :proposal_locations
   belongs_to :proposal_type
   has_many :proposal_roles, dependent: :destroy


### PR DESCRIPTION
This PR fixes an issue with `Proposal#locations` relation where it would craft another join to `ProposalLocation` when it shouldn't. 

Other changes:
* Makes `Proposal#lead_organizer` a relation, instead of the method. This allows preloading lead organizers