### PR TITLE
Move invite acceptance out of survey

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -46,6 +46,8 @@ class InvitesController < ApplicationController
         send_email_on_response
       elsif @invite.yes?
         session[:is_invited_person] = true
+        InviteMailer.with(invite: @invite).invite_acceptance.deliver_later
+
         redirect_to new_person_path(code: @invite.code, response: @invite.response)
       end
     else

--- a/app/controllers/survey_controller.rb
+++ b/app/controllers/survey_controller.rb
@@ -74,7 +74,6 @@ class SurveyController < ApplicationController
     return unless @invite.save
 
     create_role
-    send_email_on_response
   end
 
   def create_role
@@ -82,12 +81,6 @@ class SurveyController < ApplicationController
 
     proposal_role
     create_user if @invite.invited_as == 'Organizer' && !@invite.person.user
-  end
-
-  def send_email_on_response
-    return if @invite.no?
-
-    InviteMailer.with(invite: @invite).invite_acceptance.deliver_later
   end
 
   def proposal_role


### PR DESCRIPTION
This PR moves sending `InviteEmail.invite_acceptance` from `SurveyController` to `InvitesController`. This is done to always send such email even if person has already filled survey before