### PR TITLE
Move creation of ProposalRole to invite response step

### DIFF
--- a/app/controllers/survey_controller.rb
+++ b/app/controllers/survey_controller.rb
@@ -71,28 +71,7 @@ class SurveyController < ApplicationController
   def invite_response_save
     @invite.response = params[:response]
     @invite.status = 'confirmed' unless @invite.no?
-    return unless @invite.save
-
-    create_role
-  end
-
-  def create_role
-    return if @invite.no?
-
-    proposal_role
-    create_user if @invite.invited_as == 'Organizer' && !@invite.person.user
-  end
-
-  def proposal_role
-    role = Role.find_or_create_by!(name: @invite.invited_as)
-    @invite.proposal.proposal_roles.create(role: role, person: @invite.person)
-  end
-
-  def create_user
-    user = User.new(email: @invite.person.email,
-                    password: SecureRandom.urlsafe_base64(20), confirmed_at: Time.zone.now)
-    user.person = @invite.person
-    user.save
+    @invite.save
   end
 
   def post_demographic_form_path


### PR DESCRIPTION
Since accounts that filled in survey in the past are not prompted to fill in survey again, accepting invite would not create ProposalRole for them and that proposal would not be seen on `/proposals` page. This PR moves logic of crating ProposalRole to invite response capture step.