### PR TITLE
Update organizers permissions and action buttons visibility for invites

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -193,6 +193,6 @@ class InvitesController < ApplicationController
     return if current_user.staff_member?
 
     redirect_back fallback_location: edit_proposal_path(@invite.proposal),
-                  alert: I18n.t('errors.messages.not_authorized'), code: 422
+                  alert: I18n.t('errors.messages.not_authorized')
   end
 end

--- a/app/views/proposals/_organizer.html.erb
+++ b/app/views/proposals/_organizer.html.erb
@@ -36,17 +36,17 @@
 
             <div>
               <% if invite.pending? && params[:action] == 'edit' %>
-                <div><td><%= link_to '<i class="align-middle"></i>Cancel Invite'.html_safe, cancel_url(code: invite.code), class: 'btn', method: :post %>
-                <%= link_to '<i class="align-middle"></i>Invite Reminder'.html_safe, invite_reminder_proposal_invite_url(invite.proposal, invite, code: invite.code), class: 'btn', method: :post %>
-                </td></div>
-              <% elsif invite.confirmed? && params[:action] == 'edit' && lead_organizer(invite, current_user) %>
-                <div><td><%= link_to '<i class="align-middle"></i>Cancel Invite'.html_safe, cancel_confirmed_invite_url(code: invite.code), class: 'btn', method: :post %>
+                <td>
+                  <% if current_user.staff_member? %>
+                    <%= link_to '<i class="align-middle"></i>Cancel Invite'.html_safe, cancel_url(code: invite.code), class: 'btn', method: :post %>
+                  <% end %>
+                  <%= link_to '<i class="align-middle"></i>Invite Reminder'.html_safe, invite_reminder_proposal_invite_url(invite.proposal, invite, code: invite.code), class: 'btn', method: :post %>
+                </td>
+              <% elsif invite.confirmed? && params[:action] == 'edit' && current_user.staff_member? %>
+                <td>
+                  <%= link_to '<i class="align-middle"></i>Cancel Invite'.html_safe, cancel_confirmed_invite_url(code: invite.code), class: 'btn', method: :post %>
                   <button id="edit-invite-id" class="align-middle btn" data-action="click->nested-invites#editPreview" data-id="<%= invite.id %>">Edit Invite</button>
-                </td></div>
-              <% elsif invite.confirmed? && params[:action] == 'edit' %>
-                <div><td><%= link_to '<i class="align-middle"></i>Cancel Invite'.html_safe, cancel_confirmed_invite_url(code: invite.code), class: 'btn', method: :post %>
-                  <button id="edit-invite-id" class="align-middle btn" data-action="click->nested-invites#editPreview" data-id="<%= invite.id %>">Edit Invite</button>
-                </td></div>
+                </td>
               <% else %>
                 <td>-</td>
               <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
         invalid_code: This invitation code is invalid
       something_went_wrong: 'Something went wrong.'
       resource_not_found: 'Requested resource not found'
+      not_authorized: 'You are not authorized to perform this action'
       email_verifier:
         email_not_real: must point to a real mail account
         out_of_mail_server: appears to point to dead mail server

--- a/spec/requests/invites_spec.rb
+++ b/spec/requests/invites_spec.rb
@@ -334,8 +334,11 @@ RSpec.describe "/proposals/:proposal_id/invites", type: :request do
 
       it { expect(user.staff_member?).to be_falsey }
 
-      it "updates the invite status" do
-        expect(invite.reload.status).to eq('cancelled')
+      it "doest update the invite status" do
+        expect(invite.reload.status).to eq('confirmed')
+      end
+
+      it "redirects back to edit form" do
         expect(response).to redirect_to(edit_proposal_path(invite.proposal))
       end
     end

--- a/spec/requests/invites_spec.rb
+++ b/spec/requests/invites_spec.rb
@@ -314,6 +314,7 @@ RSpec.describe "/proposals/:proposal_id/invites", type: :request do
       proposal_role.role.update(name: "Organizer")
       person.proposal_roles << proposal_role
       role.update(name: role_name)
+      invite.update(status: :confirmed, response: 'yes')
 
       post cancel_confirmed_invite_path(code: invite.code), params: { invite: invite }
     end


### PR DESCRIPTION
if Invitation status = invitation accepted. Removed ‘Cancel invite’ and ‘Edit invite’
If invitation status = Not yet responded to invitation. Removed ‘Cancel invite’ but kept ‘invite reminder’.
If invitation status = invite has been cancelled. No changes applied