### PR TITLE
Add declined state to invitations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,13 +31,14 @@ gem 'redis', '~> 4.0', '>= 4.5.1'
 gem 'rest-client'
 gem 'rollbar'
 gem 'sass-rails', '>= 6'
+gem 'sucker_punch', '~> 3.0'
 gem 'tinymce-rails', '5.10.2'
 gem 'turbo-rails', '~> 1.4'
 gem 'webpacker', '~> 5.0'
-gem 'sucker_punch', '~> 3.0'
 
 group :development, :test do
   gem 'byebug'
+  gem 'rspec-rails'
   gem 'rubocop-performance'
   gem 'rubocop-rspec'
 end
@@ -47,7 +48,6 @@ group :test do
   gem 'factory_bot_rails', require: false
   gem 'faker'
   gem 'rails-controller-testing'
-  gem 'rspec-rails', '~> 4.1.0'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 4.0'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,7 +455,7 @@ DEPENDENCIES
   redis (~> 4.0, >= 4.5.1)
   rest-client
   rollbar
-  rspec-rails (~> 4.1.0)
+  rspec-rails
   rubocop-performance
   rubocop-rails
   rubocop-rspec

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -122,14 +122,7 @@ class InvitesController < ApplicationController
   end
 
   def set_invite_status
-    case response_params
-    when 'no'
-      :cancelled
-    when 'maybe'
-      :pending
-    when 'yes'
-      :confirmed
-    end
+    { 'yes' => 'confirmed', 'no' => 'declined', 'maybe' => 'pending' }[response_params]
   end
 
   def set_invite_proposal
@@ -137,7 +130,7 @@ class InvitesController < ApplicationController
   end
 
   def response_params
-    params.require(:commit)&.downcase
+    params.require(:commit).downcase
   end
 
   def invalid_response?

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -9,7 +9,7 @@ module ProposalsHelper
 
   def confirmed_participants(id, invited_as)
     Invite.where('invited_as = ? AND proposal_id = ?', invited_as, id)
-          .where.not(status: 'cancelled')
+          .where.not(status: %w[cancelled declined])
   end
 
   def proposal_type_year(proposal_type = nil)

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -109,7 +109,7 @@ class Invite < ApplicationRecord
 
   def one_invite_per_person
     return if proposal.nil? || proposal.invites.where(email: email&.downcase)
-                                       .where.not(status: 'cancelled').empty?
+                                       .where.not(status: %w[cancelled declined]).empty?
 
     errors.add('Duplicate:', "Same email cannot be used to invite already
                               invited organizers or participants.".squish)

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -24,7 +24,7 @@ class Invite < ApplicationRecord
   scope :organizer, -> { where(invited_as: 'Organizer') }
   scope :participant, -> { where(invited_as: 'Participant') }
 
-  enum status: { pending: 0, confirmed: 1, cancelled: 2 }
+  enum status: { pending: 0, confirmed: 1, cancelled: 2, declined: 3 }
   enum response: { yes: 0, maybe: 1, no: 2 }
 
   class << self

--- a/spec/helpers/invites_helper_spec.rb
+++ b/spec/helpers/invites_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe InvitesHelper, type: :helper do
   let(:invite2) { create(:invite, proposal: proposal, invited_as: "Organizer", status: :confirmed) }
 
   describe '#invite_statuses' do
-    let(:statuses) { [%w[Pending pending], %w[Confirmed confirmed], %w[Cancelled cancelled]] }
+    let(:statuses) { [%w[Pending pending], %w[Confirmed confirmed], %w[Cancelled cancelled], %w[Declined declined]] }
     it 'returns invite statuses' do
       expect(invite_statuses).to eq(statuses)
     end

--- a/spec/helpers/proposals_helper_spec.rb
+++ b/spec/helpers/proposals_helper_spec.rb
@@ -167,6 +167,8 @@ RSpec.describe ProposalsHelper, type: :helper do
   describe "#confirmed_participants" do
     let(:proposal) { create(:proposal) }
     let(:invites) { create_list(:invite, 2, proposal_id: proposal.id, invited_as: "Organizer", status: "confirmed") }
+    let(:cancelled_invite) { create(:invite, proposal_id: proposal.id, invited_as: "Organizer", status: "cancelled") }
+    let(:declined_invite) { create(:invite, proposal_id: proposal.id, invited_as: "Organizer", status: "declined") }
     it "returns confirmed participants" do
       expect(confirmed_participants(proposal.id, "Organizer")).to eq(invites)
     end

--- a/spec/requests/invites_spec.rb
+++ b/spec/requests/invites_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe "/proposals/:proposal_id/invites", type: :request do
 
         invite_response
       end
+
+      it 'update invite status' do
+        invite_response
+
+        expect(invite.reload.status).to eq('declined')
+      end
     end
 
     context 'when response is maybe' do
@@ -100,6 +106,12 @@ RSpec.describe "/proposals/:proposal_id/invites", type: :request do
         expect(InviteMailer).to receive_message_chain(:with, :invite_acceptance, :deliver_later)
 
         invite_response
+      end
+
+      it 'updates invite status' do
+        invite_response
+
+        expect(invite.reload.status).to eq('confirmed')
       end
 
       context 'when invited as Organizer' do


### PR DESCRIPTION
Previously there was pending, confirmed, cancelled states. This PR adds `declined` state, so it could be tracked and correctly displayed. 