### PR TITLE
The PDF needs to be the current content of the proposal

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -194,8 +194,8 @@ class ProposalsController < ApplicationController
 
   def generate_file
     @year = @proposal&.year || (Date.current.year.to_i + 2)
-    #version = @proposal.answers.maximum(:version).to_i
-    #@proposal_pdf = ProposalPdfService.new(@proposal.id, latex_temp_file, 'all', current_user, version)
+    # version = @proposal.answers.maximum(:version).to_i
+    # @proposal_pdf = ProposalPdfService.new(@proposal.id, latex_temp_file, 'all', current_user, version)
     @proposal_pdf = ProposalPdfService.new(@proposal.id, latex_temp_file, 'all', current_user)
                                       .generate_latex_file
     @latex_infile = @proposal_pdf.to_s

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -194,8 +194,9 @@ class ProposalsController < ApplicationController
 
   def generate_file
     @year = @proposal&.year || (Date.current.year.to_i + 2)
-    version = @proposal.answers.maximum(:version).to_i
-    @proposal_pdf = ProposalPdfService.new(@proposal.id, latex_temp_file, 'all', current_user, version)
+    #version = @proposal.answers.maximum(:version).to_i
+    #@proposal_pdf = ProposalPdfService.new(@proposal.id, latex_temp_file, 'all', current_user, version)
+    @proposal_pdf = ProposalPdfService.new(@proposal.id, latex_temp_file, 'all', current_user)
                                       .generate_latex_file
     @latex_infile = @proposal_pdf.to_s
   end


### PR DESCRIPTION
This change removes the version argument in PDF generation so that information for the proposal pdf comes from the `Proposal` object rather than the `ProposalVersion` object.