### PR TITLE
The mailing address fields should only be shown if it is not already …

### DIFF
--- a/app/views/people/new.html.erb
+++ b/app/views/people/new.html.erb
@@ -43,8 +43,8 @@
                     <%= f.select :first_phd_year, phd_year_options, {include_blank: true}, class:'form-select' %>
                   </div>
                   <div>
-                    <% if @person.lead_organizer? %>
-                      <h3>Mailing Address:</h3>
+                    <% if @person.lead_organizer? and not @person.city? %>
+                      <h3>Institutional Mailing Address:</h3>
                       <div class="form-group mb-2">
                         <%= f.label :street_1, "Street 1" , class: 'form-label required' %>
                         <%= f.text_field :street_1, class:'form-control'%>

--- a/app/views/profiles/_person_data.html.erb
+++ b/app/views/profiles/_person_data.html.erb
@@ -42,7 +42,7 @@
     </div>
     <div>
       <% if @person.lead_organizer? %>
-        <h3>Mailing Address:</h3>
+        <h3>Institutional Mailing Address:</h3>
         <div class="form-group mb-2">
           <%= f.label :street_1, "Street 1" , class: 'form-label required' %>
           <%= f.text_field :street_1, class: 'form-control'%>


### PR DESCRIPTION
The mailing address fields should only be shown in very specific circumstances. In particular, if the person is a lead organizer (on this proposal or another) and we don't already know their address. Also change the wording to make it clear that we only need an institutional address here.