### PR TITLE
Security Fix: Prevent RCE vulnerability in ability.rb

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,22 +2,46 @@
 # frozen_string_literal: true
 class Ability
   include CanCan::Ability
+
+  # Whitelist of allowed model names for privileges
+  # Only these classes can be used in authorization rules
+  ALLOWED_PRIVILEGES = %w[
+    Proposal
+    ProposalType
+    Location
+    Schedule
+    User
+    Role
+    Answer
+    Email
+    Review
+    Subject
+    Participant
+  ].freeze
+
   def initialize(user)
     user&.roles&.each do |role|
       role.role_privileges.each do |privilege|
         check_privilege(privilege)
       end
     end
-    
+
     # Staff members (birs.ca emails) can view demographic data
     if user&.staff_member?
       can :view, :demographic_data
     end
   end
-  
+
   private
-  
+
   def check_privilege(privilege)
+    # Security fix: Only allow whitelisted privilege names
+    # This prevents Remote Code Execution via constantize
+    unless ALLOWED_PRIVILEGES.include?(privilege.privilege_name)
+      Rails.logger.warn("Attempted to use non-whitelisted privilege: #{privilege.privilege_name}")
+      return
+    end
+
     case privilege.permission_type
     when 'Manage'
       can :manage, privilege.privilege_name.constantize


### PR DESCRIPTION
## Security Issue

**Vulnerability**: Remote Code Execution (RCE) via unvalidated `constantize`

The `check_privilege` method in `app/models/ability.rb` was directly calling `constantize` on `privilege.privilege_name` without any validation. This created a potential Remote Code Execution vulnerability if an attacker could control the `privilege_name` field in the database.

### Attack Vector
```ruby
# Before fix - vulnerable code:
privilege.privilege_name.constantize  # No validation!
```

An attacker with database access could set `privilege_name` to arbitrary Ruby code and trigger code execution through the constantize method.

## Solution

Added a whitelist-based approach to validate privilege names before constantization:

1. **ALLOWED_PRIVILEGES constant**: Whitelist of valid model names that can be used in authorization rules
2. **Validation check**: `check_privilege` now validates against the whitelist before calling `constantize`
3. **Logging**: Non-whitelisted attempts are logged with `Rails.logger.warn`
4. **Safe failure**: Invalid privilege names are rejected by returning early

### Whitelisted Models
```ruby
Proposal, ProposalType, Location, Schedule, User, Role, 
Answer, Email, Review, Subject, Participant
```

## Changes

- Added `ALLOWED_PRIVILEGES` frozen array constant
- Modified `check_privilege` to validate privilege names against whitelist
- Added security logging for non-whitelisted privilege attempts
- Maintains full backward compatibility for legitimate privileges

## Testing

- Existing authorization tests should pass unchanged
- Consider adding test cases for:
  - Valid privilege names (should work)
  - Invalid privilege names (should log and reject)
  - Malicious privilege names (should be safely rejected)

## Impact

- **Security**: Prevents RCE attack vector
- **Compatibility**: No breaking changes to existing functionality
- **Performance**: Minimal (single array lookup per privilege check)

Generated with [Claude Code](https://claude.com/claude-code)