### PR TITLE
fix(docker): refresh Yarn apt signing key so cold builds work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,12 @@ ENV HOME /root
 CMD ["/sbin/my_init"]
 
 # Yarn package
-RUN curl -sS https://raw.githubusercontent.com/yarnpkg/releases/gh-pages/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+# The old gh-pages pubkey URL no longer carries Yarn's current signing key (62D54FD4003F6525),
+# so `apt-get update` fails ("NO_PUBKEY ... dl.yarnpkg.com ... is not signed") on a from-scratch
+# build. Fetch the canonical key into a keyring and pin the repo to it with signed-by.
+# (Same class of infra rot as the phusion repo below, not related to the Ruby/Rails bump.)
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/yarnkey.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" > /etc/apt/sources.list.d/yarn.list
 
 # Postgres
 RUN curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -


### PR DESCRIPTION
## Problem

A from-scratch (uncached) image build currently fails at `apt-get update`:

```
W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: NO_PUBKEY 62D54FD4003F6525
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
```

The Dockerfile fetched Yarn's signing key from the old `raw.githubusercontent.com/yarnpkg/releases/gh-pages/.../pubkey.gpg` URL, which no longer carries Yarn's current signer (`62D54FD4003F6525`). The key rotated since this image was last built, so any clean build breaks before installing a single gem. Layer caching hides it on machines that built previously.

This is the same class of apt-repo bit-rot already fixed for the phusion passenger repo in `512c273e` — just the next domino.

## Fix

Fetch the canonical key from `dl.yarnpkg.com` into a keyring and pin the repo to it with `signed-by` (replacing the deprecated `apt-key`). Build-only change — no app, gem, or runtime impact.

## Verification

This exact change produced the image **currently running in production** (`proposals.birs.ca`, Ruby 2.7.8 / Rails 6.1.7.10), built cold on the prod host. The Yarn repo's `InRelease` now verifies (apt exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)